### PR TITLE
Maintain continuous gradient across sections

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -97,7 +97,7 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="bg-[#0A0A14] min-h-screen text-gray-100 selection:bg-purple-500 selection:text-white">
+    <div className="min-h-screen text-gray-100 selection:bg-purple-500 selection:text-white">
       <AnimatedCursor />
       <Navbar 
         setActiveSection={setActiveSection} 

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -5,7 +5,7 @@ import { FooterProps } from '../../types';
 
 const Footer: React.FC<FooterProps> = ({ personalData }) => {
   return (
-    <footer className="py-10 bg-[#0A0A14] text-center text-gray-400 border-t border-gray-700/30">
+    <footer className="py-10 text-center text-gray-400 border-t border-gray-700/30">
       <p className="text-sm">&copy; {new Date().getFullYear()} {personalData.name}. All rights reserved.</p>
       <div className="flex justify-center space-x-6 mt-4">
           <a 

--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -25,8 +25,9 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
   return (
     <AnimatePresence>
       {progress < 100 && (
-        <motion.div 
-          className="fixed inset-0 bg-[#0A0A14] flex flex-col items-center justify-center z-[10000]"
+        <motion.div
+          className="fixed inset-0 flex flex-col items-center justify-center z-[10000]"
+          style={{ background: 'linear-gradient(to bottom, #1e1e3f, #2b1452)' }}
           exit={{ opacity: 0, y: -50, transition: { duration: 0.5, ease: "easeInOut" } }}
         >
           <motion.div 

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -34,7 +34,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
   };
 
   return (
-    <Section id="about" className="bg-[#100F1C] text-white" refProp={refProp}>
+    <Section id="about" className="text-white" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -25,7 +25,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
   ];
   
   return (
-    <Section id="contact" className="bg-gradient-to-br from-[#1A1A2E] to-[#121224] text-white" refProp={refProp} fullHeight>
+    <Section id="contact" className="text-white" refProp={refProp} fullHeight>
       <motion.div
         className="text-center mb-12 md:mb-16"
         initial="hidden"

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -20,7 +20,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
   };
 
   return (
-    <Section id="experience" className="bg-[#100F1C] text-white" refProp={refProp}>
+    <Section id="experience" className="text-white" refProp={refProp}>
       <motion.div
         className="text-center mb-16 md:mb-20"
         initial="hidden"

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -37,7 +37,7 @@ const Hero: React.FC<HeroProps> = ({ scrollToSection, refProp, personalData, typ
   return (
     <Section
       id="home"
-      className="bg-gradient-to-b from-[#0f0c29] via-[#302b63] to-black text-white"
+      className="text-white"
       fullHeight
       refProp={refProp}
     >

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -95,7 +95,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
   };
 
   return (
-    <Section id="projects" className="bg-[#0F0F1A] text-white" refProp={refProp}>
+    <Section id="projects" className="text-white" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -51,7 +51,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
   };
 
   return (
-    <Section id="skills" className="bg-gradient-to-br from-[#121224] to-[#1A1A2E] text-white" refProp={refProp}>
+    <Section id="skills" className="text-white" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 

--- a/index.html
+++ b/index.html
@@ -15,9 +15,7 @@
             /* Text styling */
             color: #E0E0E0; /* Base text color */
             font-family: 'Inter', sans-serif; /* Default font */
-            background: linear-gradient(130deg,#1a1a2e,#0f0c29,#302b63,#24243e);
-            background-size: 400% 400%;
-            animation: gradient-bg 20s ease infinite;
+            background: linear-gradient(to bottom, #1e1e3f, #2b1452);
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- apply global gradient background on `<body>`
- remove per-section background colors so gradient persists
- style preloader with same gradient
- keep footer transparent

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684254364104832d97dfd2939ee16151