### PR TITLE
Fix gradient background and adjust resume button

### DIFF
--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -27,7 +27,7 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
       {progress < 100 && (
         <motion.div
           className="fixed inset-0 flex flex-col items-center justify-center z-[10000]"
-          style={{ background: 'linear-gradient(to bottom, #1e1e3f, #2b1452)' }}
+          style={{ background: 'radial-gradient(circle at center, #2b1452, #1e1e3f)' }}
           exit={{ opacity: 0, y: -50, transition: { duration: 0.5, ease: "easeInOut" } }}
         >
           <motion.div 

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -95,24 +95,24 @@ const Hero: React.FC<HeroProps> = ({ scrollToSection, refProp, personalData, typ
           <span>{typedText}</span><span className="animate-pulse">_</span> 
         </motion.div>
         <motion.div variants={itemVariants} className="flex flex-row flex-wrap items-center justify-center gap-4 md:gap-6">
-          <motion.button 
-            onClick={() => scrollToSection('projects')} 
-            className="px-8 py-3.5 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-pink-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg" 
+          <motion.button
+            onClick={() => scrollToSection('projects')}
+            className="px-8 py-3.5 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-pink-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
             whileHover={{ boxShadow: "0px 0px 25px rgba(236, 72, 153, 0.6)" }} 
             whileTap={{ scale: 0.95 }} 
             data-cursor-hover-link
           >
             View My Work
           </motion.button>
-          <motion.a 
-            href={personalData.resumeUrl} 
-            download 
-            className="px-8 py-3.5 border-2 border-purple-400 text-purple-400 font-semibold rounded-xl hover:bg-purple-400 hover:text-white transition-colors duration-300 text-md md:text-lg flex items-center justify-center" 
-            whileHover={{ scale: 1.05, boxShadow: "0px 0px 15px rgba(168, 85, 247, 0.4)" }} 
-            whileTap={{ scale: 0.95 }} 
+          <motion.a
+            href={personalData.resumeUrl}
+            download
+            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 border-2 border-purple-400 text-purple-400 font-semibold rounded-xl hover:bg-purple-400 hover:text-white transition-colors duration-300 text-md md:text-lg"
+            whileHover={{ scale: 1.05, boxShadow: "0px 0px 15px rgba(168, 85, 247, 0.4)" }}
+            whileTap={{ scale: 0.95 }}
             data-cursor-hover-link
           >
-            Download CV <Download size={20} className="inline ml-2.5" />
+            Download CV <Download size={20} />
           </motion.a>
         </motion.div>
       </motion.div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             /* Text styling */
             color: #E0E0E0; /* Base text color */
             font-family: 'Inter', sans-serif; /* Default font */
-            background: linear-gradient(to bottom, #1e1e3f, #2b1452);
+            background: radial-gradient(circle at center, #2b1452, #1e1e3f);
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- apply radial gradient to body background
- use same radial gradient for Preloader
- tweak resume button layout with flex and internal arrow icon

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842559311b4832da5800bcc2d348bf6