### PR TITLE
Fix light and dark themes

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -5,14 +5,14 @@ import { FooterProps } from '../../types';
 
 const Footer: React.FC<FooterProps> = ({ personalData }) => {
   return (
-    <footer className="py-10 text-center text-gray-400 border-t border-gray-700/30">
+    <footer className="py-10 text-center text-gray-600 dark:text-gray-400 border-t border-gray-700/30">
       <p className="text-sm">&copy; {new Date().getFullYear()} {personalData.name}. All rights reserved.</p>
       <div className="flex justify-center space-x-6 mt-4">
           <a 
             href={personalData.github} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-400 hover:text-purple-400 transition-colors" 
+            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} GitHub Profile`}
           >
@@ -22,7 +22,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.linkedin} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-400 hover:text-purple-400 transition-colors" 
+            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} LinkedIn Profile`}
           >
@@ -30,7 +30,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
           </a>
           <a 
             href={`mailto:${personalData.email}`} 
-            className="text-gray-400 hover:text-purple-400 transition-colors" 
+            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
             data-cursor-hover-link
             aria-label={`Email ${personalData.name}`}
           >

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -24,8 +24,8 @@ const Navbar: React.FC<NavbarProps> = ({ setActiveSection, currentSection, perso
     setIsOpen(false); // Close mobile menu on item click
   };
 
-  const navLinkClasses = (item: string) => 
-    `text-gray-300 hover:text-purple-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-purple-400 font-semibold' : ''}`;
+  const navLinkClasses = (item: string) =>
+    `text-gray-800 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-purple-600 dark:text-purple-400 font-semibold' : ''}`;
   
   const activeIndicator = (item: string) => 
     currentSection === item.toLowerCase() && (
@@ -45,8 +45,8 @@ const Navbar: React.FC<NavbarProps> = ({ setActiveSection, currentSection, perso
       transition={{ duration: 0.6, delay: 0.5, ease: "easeOut" }}
     >
       <div className="container mx-auto px-6 md:px-12 flex justify-between items-center">
-        <motion.div 
-          className="text-3xl font-bold text-white cursor-pointer" 
+        <motion.div
+          className="text-3xl font-bold text-gray-900 dark:text-white cursor-pointer"
           onClick={() => handleNavClick('home')}
           whileHover={{ scale: 1.05, color: '#A78BFA' }} // purple-400
           data-cursor-hover-link
@@ -79,7 +79,7 @@ const Navbar: React.FC<NavbarProps> = ({ setActiveSection, currentSection, perso
           </motion.a>
           <button
             onClick={toggleTheme}
-            className="text-gray-300 hover:text-yellow-400 transition-colors"
+            className="text-gray-700 dark:text-gray-300 hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors"
             aria-label="Toggle theme"
             data-cursor-hover-link
           >
@@ -88,9 +88,9 @@ const Navbar: React.FC<NavbarProps> = ({ setActiveSection, currentSection, perso
         </div>
 
         <div className="md:hidden">
-          <button 
-            onClick={() => setIsOpen(!isOpen)} 
-            className="text-white focus:outline-none z-50" 
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className="text-gray-900 dark:text-white focus:outline-none z-50"
             data-cursor-hover-link
             aria-label={isOpen ? "Close menu" : "Open menu"}
           >
@@ -129,7 +129,7 @@ const Navbar: React.FC<NavbarProps> = ({ setActiveSection, currentSection, perso
               </motion.a>
               <button
                 onClick={toggleTheme}
-                className="text-gray-300 hover:text-yellow-400 transition-colors"
+                className="text-gray-700 dark:text-gray-300 hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors"
                 aria-label="Toggle theme"
                 data-cursor-hover-link
               >

--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -50,8 +50,8 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
               transition={{ duration: 0.1, ease: "linear" }} // Faster bar update
             />
           </div>
-          <motion.p 
-            className="text-white mt-5 text-lg font-mono tracking-wider"
+          <motion.p
+            className="text-gray-900 dark:text-white mt-5 text-lg font-mono tracking-wider"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.5 }}

--- a/components/common/Section.tsx
+++ b/components/common/Section.tsx
@@ -7,7 +7,7 @@ const Section: React.FC<SectionProps> = ({ children, id, className = '', fullHei
     <motion.section
       ref={refProp}
       id={id}
-      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 ${className}`}
+      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-800 dark:text-gray-100 ${className}`}
       data-testid={`section-${id}`} // For testing
     >
       <div className={`container mx-auto relative z-10 

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -34,7 +34,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
   };
 
   return (
-    <Section id="about" className="text-white" refProp={refProp}>
+    <Section id="about" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 
@@ -48,7 +48,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         >
           Discover More About Me
         </h2>
-        <p className="text-lg text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
+        <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
           A brief look into my journey, skills, and what drives my passion for technology.
         </p>
       </motion.div>
@@ -76,8 +76,8 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         </motion.div>
         
         <motion.div className="space-y-6" variants={textContentVariants}>
-          <motion.h3 
-            className="text-3xl md:text-4xl font-semibold text-gray-100 leading-tight" 
+          <motion.h3
+            className="text-3xl md:text-4xl font-semibold text-gray-800 dark:text-gray-100 leading-tight"
             variants={paragraphVariants} 
             data-cursor-hover-text
           >
@@ -86,7 +86,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
           {bio.map((paragraph, index) => (
             <motion.p 
               key={index} 
-              className="text-gray-300 leading-relaxed text-md md:text-lg" 
+              className="text-gray-700 dark:text-gray-300 leading-relaxed text-md md:text-lg"
               variants={paragraphVariants} 
               data-cursor-hover-text
             >
@@ -100,7 +100,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
                 {strengths.map((strength, index) => (
                   <motion.li 
                     key={index} 
-                    className="flex items-center text-gray-300" 
+                    className="flex items-center text-gray-700 dark:text-gray-300"
                     variants={strengthItemVariants} 
                     data-cursor-hover-text
                   >

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -21,12 +21,12 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
   const contactMethods = [
     { icon: <Mail size={28} className="text-pink-400"/>, label: "Email Me", value: personalData.email, href: `mailto:${personalData.email}` },
     { icon: <Linkedin size={28} className="text-blue-400"/>, label: "Connect on LinkedIn", value: personalData.linkedin.split('/').pop() || personalData.linkedin, href: personalData.linkedin, target: "_blank" },
-    { icon: <Github size={28} className="text-gray-300"/>, label: "View My GitHub", value: personalData.github.split('/').pop() || personalData.github, href: personalData.github, target: "_blank" },
+    { icon: <Github size={28} className="text-gray-500 dark:text-gray-300"/>, label: "View My GitHub", value: personalData.github.split('/').pop() || personalData.github, href: personalData.github, target: "_blank" },
     { icon: <ListChecks size={28} className="text-orange-400"/>, label: "My LeetCode", value: personalData.leetcode.split('/').pop() || personalData.leetcode, href: personalData.leetcode, target: "_blank" },
   ];
   
   return (
-    <Section id="contact" className="text-white" refProp={refProp} fullHeight>
+    <Section id="contact" refProp={refProp} fullHeight>
       <motion.div
         className="text-center mb-12 md:mb-16"
         initial="hidden"
@@ -41,7 +41,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
           Let's Get In Touch
         </h2>
         <p
-          className="text-lg text-gray-400 max-w-xl mx-auto mb-6"
+          className="text-lg text-gray-600 dark:text-gray-400 max-w-xl mx-auto mb-6"
           data-cursor-hover-text
         >
           {personalData.contact.intro}
@@ -67,15 +67,15 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
               {method.icon}
             </div>
             <div>
-              <h4 className="text-lg md:text-xl font-semibold text-gray-200 group-hover:text-purple-300 transition-colors duration-300">{method.label}</h4>
-              <p className="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300 break-all">{method.value}</p>
+              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-purple-500 dark:group-hover:text-purple-300 transition-colors duration-300">{method.label}</h4>
+              <p className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300 transition-colors duration-300 break-all">{method.value}</p>
             </div>
             <Send size={22} className="ml-auto text-gray-500 group-hover:text-purple-400 transition-all duration-300 transform group-hover:translate-x-1"/>
           </motion.a>
         ))}
       </div>
-       <motion.p 
-        className="text-center text-xl md:text-2xl text-gray-300 mt-16 md:mt-20 font-semibold"
+       <motion.p
+        className="text-center text-xl md:text-2xl text-gray-700 dark:text-gray-300 mt-16 md:mt-20 font-semibold"
         custom={contactMethods.length}
         variants={itemVariants}
         initial="hidden"

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -20,7 +20,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
   };
 
   return (
-    <Section id="experience" className="text-white" refProp={refProp}>
+    <Section id="experience" refProp={refProp}>
       <motion.div
         className="text-center mb-16 md:mb-20"
         initial="hidden"
@@ -35,7 +35,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
           My Journey & Milestones
         </h2>
         <p
-          className="text-lg text-gray-400 max-w-2xl mx-auto"
+          className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto"
           data-cursor-hover-text
         >
           A timeline of my educational background and professional experiences.
@@ -74,10 +74,10 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
               <div className="p-6 bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-purple-500/70 transition-colors duration-300">
                 <h3 className="text-xl md:text-2xl font-semibold text-purple-300 mb-1" data-cursor-hover-text>{exp.role}</h3>
                 <p className="text-md text-sky-300 mb-2" data-cursor-hover-text>{exp.company}</p>
-                <p className="text-xs text-gray-400 mb-3 flex items-center" data-cursor-hover-text>
+                <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 flex items-center" data-cursor-hover-text>
                   <CalendarDays size={14} className="mr-2 text-gray-500"/> {exp.duration}
                 </p>
-                <p className="text-gray-300 text-sm leading-relaxed" data-cursor-hover-text>{exp.description}</p>
+                <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed" data-cursor-hover-text>{exp.description}</p>
               </div>
             </div>
           </motion.div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -40,7 +40,7 @@ const Hero: React.FC<HeroProps> = ({
   const typedText = useTypewriter(typewriterWords);
 
   return (
-    <Section id="home" className="text-white" fullHeight refProp={refProp}>
+    <Section id="home" fullHeight refProp={refProp}>
       <div className="absolute inset-0 overflow-hidden z-0">
         {/* Using Tailwind arbitrary values for positioning percentages */}
         <motion.div
@@ -118,13 +118,13 @@ const Hero: React.FC<HeroProps> = ({
         </motion.h1>
         <motion.p
           variants={itemVariants}
-          className="text-sm sm:text-base text-gray-400 font-mono mb-2 sm:mb-3 text-center"
+          className="text-sm sm:text-base text-gray-600 dark:text-gray-400 font-mono mb-2 sm:mb-3 text-center"
         >
           {personalData.title}
         </motion.p>
         <motion.div
           variants={itemVariants}
-          className="text-lg md:text-xl lg:text-2xl text-gray-300 max-w-xl md:max-w-2xl mb-8 md:mb-10 font-mono h-16 md:h-auto min-h-[4rem] md:min-h-[auto] text-center"
+          className="text-lg md:text-xl lg:text-2xl text-gray-700 dark:text-gray-300 max-w-xl md:max-w-2xl mb-8 md:mb-10 font-mono h-16 md:h-auto min-h-[4rem] md:min-h-[auto] text-center"
           data-cursor-hover-text
         >
           <span>{typedText}</span>

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -30,11 +30,11 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
       <h3 className="text-xl md:text-2xl font-semibold text-purple-300 mb-2 group-hover:text-purple-200 transition-colors" data-cursor-hover-text>
         {project.title}
       </h3>
-      <p className="text-gray-400 text-sm md:text-base leading-relaxed mb-4 flex-grow" data-cursor-hover-text>
+      <p className="text-gray-600 dark:text-gray-400 text-sm md:text-base leading-relaxed mb-4 flex-grow" data-cursor-hover-text>
         {project.description}
       </p>
       {project.duration && (
-        <p className="text-xs text-gray-500 mb-3" data-cursor-hover-text>
+        <p className="text-xs text-gray-600 dark:text-gray-500 mb-3" data-cursor-hover-text>
             Timeline: {project.duration}
         </p>
       )}
@@ -54,7 +54,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
             href={project.githubUrl} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="inline-flex items-center text-gray-300 hover:text-purple-400 transition-colors duration-200" 
+            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
             whileHover={{ scale: 1.05 }} 
             data-cursor-hover-link
           >
@@ -66,7 +66,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
             href={project.liveUrl} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="inline-flex items-center text-gray-300 hover:text-green-400 transition-colors duration-200" 
+            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-green-500 dark:hover:text-green-400 transition-colors duration-200"
             whileHover={{ scale: 1.05 }} 
             data-cursor-hover-link
           >
@@ -95,7 +95,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
   };
 
   return (
-    <Section id="projects" className="text-white" refProp={refProp}>
+    <Section id="projects" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 
@@ -106,7 +106,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
         <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-pink-500 via-red-500 to-orange-500" data-cursor-hover-text>
           My Featured Creations
         </h2>
-        <p className="text-lg text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
+        <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
           Here's a selection of projects that showcase my skills and passion for building.
         </p>
       </motion.div>

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -51,7 +51,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
   };
 
   return (
-    <Section id="skills" className="text-white" refProp={refProp}>
+    <Section id="skills" refProp={refProp}>
       <motion.div 
         className="text-center mb-16 md:mb-20" 
         initial="hidden" 
@@ -62,7 +62,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
         <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-green-400 via-emerald-400 to-teal-500" data-cursor-hover-text>
           My Technical Arsenal
         </h2>
-        <p className="text-lg text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
+        <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
           A collection of technologies and tools I excel in and use to build innovative solutions.
         </p>
       </motion.div>
@@ -94,7 +94,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
                   data-cursor-hover-link
                 >
                   {skill.icon && React.cloneElement(skill.icon, { size: 40, className: `mb-3 group-hover:scale-110 transition-transform duration-300 ${skill.icon.props.className || ''}` })}
-                  <span className="text-md md:text-lg font-medium text-gray-200 group-hover:text-purple-300 transition-colors duration-300 text-center">{skill.name}</span>
+                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-purple-500 dark:group-hover:text-purple-300 transition-colors duration-300 text-center">{skill.name}</span>
                   {skill.proficiency && (
                     <div className="w-full h-2.5 bg-gray-600 rounded-full mt-3 overflow-hidden">
                       <motion.div 

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
         }
         :root {
             --text-color: #E0E0E0;
-            --gradient-from: #2b1452;
-            --gradient-to: #1e1e3f;
+            --gradient-from: #1a1a1a;
+            --gradient-to: #0f0f0f;
         }
         body {
             /* Text styling */
@@ -32,8 +32,8 @@
         }
         body.dark {
             --text-color: #E0E0E0;
-            --gradient-from: #2b1452;
-            --gradient-to: #1e1e3f;
+            --gradient-from: #1a1a1a;
+            --gradient-to: #0f0f0f;
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {
@@ -43,7 +43,7 @@
             background: #121224; /* Darker track for contrast */
         }
         body::-webkit-scrollbar-thumb {
-            background-color: #8A2BE2; /* Purple accent for thumb */
+            background-color: #4B5563; /* Standard dark thumb */
             border-radius: 10px;
             border: 2px solid #121224; /* Border matching track */
         }


### PR DESCRIPTION
## Summary
- tweak gradient colors for dark mode
- make sections inherit dark/light colors
- polish footer colors
- update navbar for light theme
- improve text colors across sections
- support theme toggle in preloader

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fddfcd6c832dada1115f152d3464