### PR TITLE
Switch to light glass look

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,7 @@ import Footer from './components/common/Footer';
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [activeSection, setActiveSection] = useState('home');
-  const [isDark, setIsDark] = useState(true);
+  const [isDark, setIsDark] = useState(false);
 
   const homeRef = useRef<HTMLElement | null>(null);
   const aboutRef = useRef<HTMLElement | null>(null);

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -39,7 +39,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
 
   return (
     <motion.nav 
-      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${scrolled || isOpen ? 'bg-[#0A0A14]/80 backdrop-blur-md shadow-xl py-4' : 'bg-transparent py-6'}`}
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${scrolled || isOpen ? 'bg-white/70 dark:bg-[#0A0A14]/80 backdrop-blur-md shadow-xl py-4' : 'bg-transparent py-6'}`}
       initial={{ y: -100, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6, delay: 0.5, ease: "easeOut" }}
@@ -106,7 +106,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
             animate={{ opacity: 1, height: 'auto' }} 
             exit={{ opacity: 0, height: 0, transition: { duration: 0.3 } }} 
             transition={{ duration: 0.4, ease: "easeInOut" }} 
-            className="md:hidden absolute top-full left-0 right-0 bg-[#0A0A14]/95 backdrop-blur-lg shadow-2xl border-t border-gray-700/50"
+            className="md:hidden absolute top-full left-0 right-0 bg-white/90 dark:bg-[#0A0A14]/95 backdrop-blur-lg shadow-2xl border-t border-gray-700/50"
           >
             <div className="flex flex-col items-center py-6 space-y-5">
               {NAV_ITEMS.map((item) => (

--- a/components/common/Section.tsx
+++ b/components/common/Section.tsx
@@ -7,7 +7,7 @@ const Section: React.FC<SectionProps> = ({ children, id, className = '', fullHei
     <motion.section
       ref={refProp}
       id={id}
-      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-800 dark:text-gray-100 ${className}`}
+      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-800 dark:text-gray-100 bg-white/70 dark:bg-gray-900/60 backdrop-blur-lg ${className}`}
       data-testid={`section-${id}`} // For testing
     >
       <div className={`container mx-auto relative z-10 

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -60,10 +60,10 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
             initial="hidden"
             whileInView="visible"
             viewport={{ amount: 0.5 }}
-            className="flex items-center p-5 md:p-6 bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-purple-500/80 hover:bg-gray-700/60 transition-all duration-300 group"
+            className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-purple-500/80 hover:bg-gray-700/60 transition-all duration-300 group"
             data-cursor-hover-link
           >
-            <div className="mr-5 p-3 bg-gray-700/50 rounded-lg shadow-md group-hover:bg-purple-600/50 transition-colors duration-300">
+            <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-purple-600/50 transition-colors duration-300">
               {method.icon}
             </div>
             <div>

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -71,7 +71,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
 
             {/* Content Card */}
             <div className={`w-full md:w-[calc(50%-2rem)] ${index % 2 === 0 ? 'ml-12 md:ml-8' : 'ml-12 md:mr-8 md:ml-0'} `}>
-              <div className="p-6 bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-purple-500/70 transition-colors duration-300">
+              <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-purple-500/70 transition-colors duration-300">
                 <h3 className="text-xl md:text-2xl font-semibold text-purple-300 mb-1" data-cursor-hover-text>{exp.role}</h3>
                 <p className="text-md text-sky-300 mb-2" data-cursor-hover-text>{exp.company}</p>
                 <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 flex items-center" data-cursor-hover-text>

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -7,7 +7,7 @@ import Section from '../common/Section';
 
 // ProjectCard Component - defined outside Projects to avoid re-creation on parent render
 const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
-  <div className="flex flex-col bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-purple-500/70 transition-all duration-300 h-full">
+  <div className="flex flex-col bg-white/60 dark:bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-purple-500/70 transition-all duration-300 h-full">
     <div className="relative overflow-hidden h-52 md:h-60">
       <img 
         src={project.imageUrl} 

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -72,7 +72,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
           <motion.div 
             key={category} 
             variants={categoryCardVariants}
-            className="p-6 md:p-8 bg-gray-800/30 backdrop-blur-md rounded-xl shadow-2xl border border-gray-700/50"
+            className="p-6 md:p-8 bg-white/50 dark:bg-gray-800/30 backdrop-blur-md rounded-xl shadow-2xl border border-gray-700/50"
           >
             <motion.h3 
               className="text-2xl md:text-3xl font-semibold text-purple-400 mb-6 md:mb-8 flex items-center" 
@@ -89,7 +89,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
               {skillsList.map((skill, index) => (
                 <motion.div 
                   key={skill.name} 
-                  className="group relative flex flex-col items-center p-4 bg-gray-700/50 rounded-lg shadow-lg hover:shadow-purple-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-purple-500" 
+                  className="group relative flex flex-col items-center p-4 bg-white/60 dark:bg-gray-700/50 rounded-lg shadow-lg hover:shadow-purple-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-purple-500"
                   variants={skillItemVariants} 
                   data-cursor-hover-link
                 >

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
             scroll-behavior: smooth;
         }
         :root {
-            --text-color: #E0E0E0;
-            --gradient-from: #1a1a1a;
-            --gradient-to: #0f0f0f;
+            --text-color: #1f2937;
+            --gradient-from: #f8fafc;
+            --gradient-to: #e2e8f0;
         }
         body {
             /* Text styling */
@@ -27,8 +27,8 @@
         }
         body.light {
             --text-color: #1f2937;
-            --gradient-from: #ffffff;
-            --gradient-to: #d8d8d8;
+            --gradient-from: #f8fafc;
+            --gradient-to: #e2e8f0;
         }
         body.dark {
             --text-color: #E0E0E0;
@@ -40,12 +40,12 @@
             width: 8px;
         }
         body::-webkit-scrollbar-track {
-            background: #121224; /* Darker track for contrast */
+            background: #e0e0e0; /* Light track */
         }
         body::-webkit-scrollbar-thumb {
-            background-color: #4B5563; /* Standard dark thumb */
+            background-color: #a0aec0; /* Light thumb */
             border-radius: 10px;
-            border: 2px solid #121224; /* Border matching track */
+            border: 2px solid #e0e0e0;
         }
         /* Fallback for non-Webkit if needed, though Tailwind provides utilities for most things */
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap');


### PR DESCRIPTION
## Summary
- default to light mode
- adjust global colors and scrollbar for a lighter look
- give sections a glass-like background
- use light transparent cards throughout
- brighten the navbar background

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684301ff1a74832d82ad6e8ddf7ee3fc