### PR TITLE
Switch portfolio accent colors to orange

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -107,7 +107,7 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen text-inherit selection:bg-purple-500 selection:text-white">
+    <div className="min-h-screen text-inherit selection:bg-accent-orange selection:text-white">
       <Navbar
         currentSection={activeSection}
         personalData={{name: personalData.name, resumeUrl: personalData.resumeUrl}}

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.github} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} GitHub Profile`}
           >
@@ -22,7 +22,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.linkedin} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} LinkedIn Profile`}
           >
@@ -30,7 +30,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
           </a>
           <a 
             href={`mailto:${personalData.email}`} 
-            className="text-gray-600 dark:text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`Email ${personalData.name}`}
           >

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -25,13 +25,13 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
   };
 
   const navLinkClasses = (item: string) =>
-    `text-gray-800 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-purple-600 dark:text-purple-400 font-semibold' : ''}`;
+    `text-gray-800 dark:text-gray-300 hover:text-accent-orange dark:hover:text-amber-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-accent-orange dark:text-amber-400 font-semibold' : ''}`;
   
   const activeIndicator = (item: string) => 
     currentSection === item.toLowerCase() && (
       <motion.div 
         layoutId="activePill" 
-        className="absolute -bottom-1 left-0 right-0 h-0.5 bg-purple-500" 
+        className="absolute -bottom-1 left-0 right-0 h-0.5 bg-accent-orange"
         initial={false} 
         transition={{ type: "spring", stiffness: 350, damping: 30 }} 
       />
@@ -48,10 +48,10 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
         <motion.div
           className="text-3xl font-bold text-gray-900 dark:text-white cursor-pointer"
           onClick={() => handleNavClick('home')}
-          whileHover={{ scale: 1.05, color: '#A78BFA' }} // purple-400
+          whileHover={{ scale: 1.05, color: '#FF6B35' }}
           data-cursor-hover-link
         >
-          {personalData.name.split(' ')[0]}<span className="text-purple-400">.</span>
+          {personalData.name.split(' ')[0]}<span className="text-accent-orange">.</span>
         </motion.div>
         
         <div className="hidden md:flex space-x-8 items-center">
@@ -71,8 +71,8 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
           <motion.a
             href={personalData.resumeUrl}
             download
-            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-purple-500/50 transition-all duration-300 transform hover:scale-105"
-            whileHover={{ boxShadow: "0px 0px 15px rgba(167, 139, 250, 0.6)" }}
+            className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-amber-500/50 transition-all duration-300 transform hover:scale-105"
+            whileHover={{ boxShadow: "0px 0px 15px rgba(255, 107, 53, 0.6)" }}
             data-cursor-hover-link
           >
             Resume
@@ -114,7 +114,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
               <motion.a
                 href={personalData.resumeUrl}
                 download
-                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
+                className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
                 data-cursor-hover-link
               >
                 Resume

--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -40,11 +40,11 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
             animate={{ scale: 1, rotateY: 0 }}
             transition={{ duration: 1, type: 'spring', stiffness: 120, delay: 0.2 }}
           >
-            <Layers size={80} className="text-purple-500 filter drop-shadow-[0_0_15px_rgba(168,85,247,0.6)]" />
+            <Layers size={80} className="text-accent-orange filter drop-shadow-[0_0_15px_rgba(255,107,53,0.6)]" />
           </motion.div>
           <div className="w-72 h-2.5 bg-gray-700 rounded-full overflow-hidden shadow-inner">
             <motion.div 
-              className="h-full bg-gradient-to-r from-purple-500 via-pink-500 to-red-500 rounded-full"
+              className="h-full bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500 rounded-full"
               initial={{ width: 0 }}
               animate={{ width: `${progress}%` }}
               transition={{ duration: 0.1, ease: "linear" }} // Faster bar update

--- a/components/common/Section.tsx
+++ b/components/common/Section.tsx
@@ -7,7 +7,7 @@ const Section: React.FC<SectionProps> = ({ children, id, className = '', fullHei
     <motion.section
       ref={refProp}
       id={id}
-      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-800 dark:text-gray-100 bg-white/70 dark:bg-gray-900/60 backdrop-blur-lg ${className}`}
+      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-200 dark:text-gray-100 bg-black ${className}`}
       data-testid={`section-${id}`} // For testing
     >
       <div className={`container mx-auto relative z-10 

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -42,8 +42,8 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={titleVariants}
       >
-        <h2 
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-sky-400 via-cyan-400 to-teal-500" 
+        <h2
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-amber-500"
           data-cursor-hover-text
         >
           Discover More About Me
@@ -61,7 +61,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         variants={contentContainerVariants}
       >
         <motion.div className="relative group" variants={imageVariants}>
-          <div className="absolute -inset-0.5 bg-gradient-to-r from-purple-600 to-pink-600 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
+          <div className="absolute -inset-0.5 bg-gradient-to-r from-orange-600 to-amber-600 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
           <img 
             src={profileImageUrl} 
             alt={personalData.name} 
@@ -95,7 +95,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
           ))}
           {strengths && strengths.length > 0 && (
             <motion.div className="mt-8 pt-6 border-t border-gray-700/50" variants={paragraphVariants}>
-              <h4 className="text-xl font-semibold text-sky-300 mb-4" data-cursor-hover-text>Core Strengths:</h4>
+              <h4 className="text-xl font-semibold text-amber-300 mb-4" data-cursor-hover-text>Core Strengths:</h4>
               <motion.ul className="space-y-3" variants={contentContainerVariants}> {/* Stagger children for list items */}
                 {strengths.map((strength, index) => (
                   <motion.li 
@@ -114,8 +114,8 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
            <motion.a 
             href={personalData.resumeUrl} 
             download 
-            className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-sky-500 to-cyan-500 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-cyan-500/40 transition-all duration-300 transform hover:scale-105 text-md" 
-            whileHover={{ boxShadow: "0px 0px 20px rgba(56, 189, 248, 0.6)" }} 
+            className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-amber-500/40 transition-all duration-300 transform hover:scale-105 text-md"
+            whileHover={{ boxShadow: "0px 0px 20px rgba(251, 146, 60, 0.6)" }}
             whileTap={{ scale: 0.95 }} 
             data-cursor-hover-link 
             variants={paragraphVariants}

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -35,7 +35,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-teal-400 via-cyan-400 to-sky-500"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500"
           data-cursor-hover-text
         >
           Let's Get In Touch
@@ -60,17 +60,17 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
             initial="hidden"
             whileInView="visible"
             viewport={{ amount: 0.5 }}
-            className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-purple-500/80 hover:bg-gray-700/60 transition-all duration-300 group"
+            className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-accent-orange/80 hover:bg-gray-700/60 transition-all duration-300 group"
             data-cursor-hover-link
           >
-            <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-purple-600/50 transition-colors duration-300">
+            <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-amber-600/50 transition-colors duration-300">
               {method.icon}
             </div>
             <div>
-              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-purple-500 dark:group-hover:text-purple-300 transition-colors duration-300">{method.label}</h4>
+              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-accent-orange dark:group-hover:text-amber-300 transition-colors duration-300">{method.label}</h4>
               <p className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300 transition-colors duration-300 break-all">{method.value}</p>
             </div>
-            <Send size={22} className="ml-auto text-gray-500 group-hover:text-purple-400 transition-all duration-300 transform group-hover:translate-x-1"/>
+            <Send size={22} className="ml-auto text-gray-500 group-hover:text-accent-orange transition-all duration-300 transform group-hover:translate-x-1"/>
           </motion.a>
         ))}
       </div>

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -60,7 +60,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
             {/* Icon Circle - positioned absolutely relative to this item, then adjusted by margin/padding of content */}
             <div className={`z-10 absolute left-4 md:left-1/2 top-1 transform -translate-x-1/2 
                             ${index % 2 === 0 ? 'md:translate-x-[-50%]' : 'md:translate-x-[-50%]'} 
-                            p-3 bg-purple-600 rounded-full shadow-xl border-2 border-purple-400 flex items-center justify-center`}
+                            p-3 bg-amber-600 rounded-full shadow-xl border-2 border-accent-orange flex items-center justify-center`}
             >
               {exp.icon ? React.cloneElement(exp.icon, { size:22, className: `text-white ${exp.icon.props.className || ''}`}) : <Briefcase size={22} className="text-white"/>}
             </div>
@@ -71,9 +71,9 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
 
             {/* Content Card */}
             <div className={`w-full md:w-[calc(50%-2rem)] ${index % 2 === 0 ? 'ml-12 md:ml-8' : 'ml-12 md:mr-8 md:ml-0'} `}>
-              <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-purple-500/70 transition-colors duration-300">
-                <h3 className="text-xl md:text-2xl font-semibold text-purple-300 mb-1" data-cursor-hover-text>{exp.role}</h3>
-                <p className="text-md text-sky-300 mb-2" data-cursor-hover-text>{exp.company}</p>
+              <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-accent-orange/70 transition-colors duration-300">
+                <h3 className="text-xl md:text-2xl font-semibold text-accent-orange mb-1" data-cursor-hover-text>{exp.role}</h3>
+                <p className="text-md text-amber-300 mb-2" data-cursor-hover-text>{exp.company}</p>
                 <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 flex items-center" data-cursor-hover-text>
                   <CalendarDays size={14} className="mr-2 text-gray-500"/> {exp.duration}
                 </p>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -43,7 +43,7 @@ const Hero: React.FC<HeroProps> = ({
       <div className="absolute inset-0 overflow-hidden z-0">
         {/* Using Tailwind arbitrary values for positioning percentages */}
         <motion.div
-          className="absolute w-[50vw] h-[50vw] max-w-xl max-h-xl bg-purple-600/20 rounded-full filter blur-3xl opacity-60 top-[5%] left-[10%]"
+          className="absolute w-[50vw] h-[50vw] max-w-xl max-h-xl bg-amber-600/20 rounded-full filter blur-3xl opacity-60 top-[5%] left-[10%]"
           animate={{
             x: ["-10%", "10%", "-10%"],
             y: ["-10%", "0%", "-10%"],
@@ -52,7 +52,7 @@ const Hero: React.FC<HeroProps> = ({
           transition={{ duration: 25, repeat: Infinity, ease: "easeInOut" }}
         />
         <motion.div
-          className="absolute w-[40vw] h-[40vw] max-w-lg max-h-lg bg-pink-500/20 rounded-full filter blur-3xl opacity-50 bottom-[10%] right-[15%]"
+          className="absolute w-[40vw] h-[40vw] max-w-lg max-h-lg bg-orange-500/20 rounded-full filter blur-3xl opacity-50 bottom-[10%] right-[15%]"
           animate={{
             x: ["10%", "-5%", "10%"],
             y: ["15%", "5%", "15%"],
@@ -66,7 +66,7 @@ const Hero: React.FC<HeroProps> = ({
           }}
         />
         <motion.div
-          className="absolute w-[30vw] h-[30vw] max-w-md max-h-md bg-sky-500/15 rounded-full filter blur-2xl opacity-40 top-1/2 left-[45%] -translate-x-1/2 -translate-y-1/2"
+          className="absolute w-[30vw] h-[30vw] max-w-md max-h-md bg-amber-500/15 rounded-full filter blur-2xl opacity-40 top-1/2 left-[45%] -translate-x-1/2 -translate-y-1/2"
           animate={{
             x: ["0%", "5%", "-5%", "0%"],
             y: ["-5%", "10%", "0%", "-5%"],
@@ -100,7 +100,7 @@ const Hero: React.FC<HeroProps> = ({
           data-cursor-hover-text
         >
           Hi, I'm{" "}
-          <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-400 via-pink-500 to-red-500">
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-amber-500">
             {personalData.name.split(" ")[0]}
           </span>
           <span
@@ -131,8 +131,8 @@ const Hero: React.FC<HeroProps> = ({
         >
           <motion.button
             onClick={() => scrollToSection("projects")}
-            className="px-8 py-3.5 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-pink-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
-            whileHover={{ boxShadow: "0px 0px 25px rgba(236, 72, 153, 0.6)" }}
+            className="px-8 py-3.5 bg-gradient-to-r from-orange-600 to-amber-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-amber-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
+            whileHover={{ boxShadow: "0px 0px 25px rgba(251, 146, 60, 0.6)" }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link
           >
@@ -141,10 +141,10 @@ const Hero: React.FC<HeroProps> = ({
           <motion.a
             href={personalData.resumeUrl}
             download
-            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 border-2 border-purple-400 text-purple-400 font-semibold rounded-xl hover:bg-purple-400 hover:text-white transition-colors duration-300 text-md md:text-lg"
+            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 border-2 border-accent-orange text-accent-orange font-semibold rounded-xl hover:bg-accent-orange hover:text-white transition-colors duration-300 text-md md:text-lg"
             whileHover={{
               scale: 1.05,
-              boxShadow: "0px 0px 15px rgba(168, 85, 247, 0.4)",
+              boxShadow: "0px 0px 15px rgba(255, 107, 53, 0.4)",
             }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -7,7 +7,7 @@ import Section from '../common/Section';
 
 // ProjectCard Component - defined outside Projects to avoid re-creation on parent render
 const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
-  <div className="flex flex-col bg-white/60 dark:bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-purple-500/70 transition-all duration-300 h-full">
+  <div className="flex flex-col bg-white/60 dark:bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-accent-orange/70 transition-all duration-300 h-full">
     <div className="relative overflow-hidden h-52 md:h-60">
       <img 
         src={project.imageUrl} 
@@ -27,7 +27,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
       )}
     </div>
     <div className="p-6 flex flex-col flex-grow">
-      <h3 className="text-xl md:text-2xl font-semibold text-purple-300 mb-2 group-hover:text-purple-200 transition-colors" data-cursor-hover-text>
+      <h3 className="text-xl md:text-2xl font-semibold text-accent-orange mb-2 group-hover:text-amber-300 transition-colors" data-cursor-hover-text>
         {project.title}
       </h3>
       <p className="text-gray-600 dark:text-gray-400 text-sm md:text-base leading-relaxed mb-4 flex-grow" data-cursor-hover-text>
@@ -39,10 +39,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
         </p>
       )}
       <div className="mb-4">
-        <p className="text-xs text-sky-300 mb-1 font-medium">Technologies Used:</p>
+        <p className="text-xs text-amber-300 mb-1 font-medium">Technologies Used:</p>
         <div className="flex flex-wrap gap-2">
           {project.tags.map(tag => (
-            <span key={tag} className="px-2.5 py-1 text-xs bg-sky-700/50 text-sky-200 rounded-full shadow-sm">
+            <span key={tag} className="px-2.5 py-1 text-xs bg-amber-700/50 text-amber-200 rounded-full shadow-sm">
               {tag}
             </span>
           ))}
@@ -54,7 +54,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
             href={project.githubUrl} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
+            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-accent-orange dark:hover:text-amber-400 transition-colors duration-200"
             whileHover={{ scale: 1.05 }} 
             data-cursor-hover-link
           >
@@ -103,7 +103,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-pink-500 via-red-500 to-orange-500" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500" data-cursor-hover-text>
           My Featured Creations
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -35,19 +35,19 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
 
   const getProficiencyColor = (level: number): string => {
     if (level >= 90) return "bg-green-500";
-    if (level >= 75) return "bg-sky-500";
+    if (level >= 75) return "bg-amber-500";
     if (level >= 60) return "bg-yellow-500";
     return "bg-red-500";
   };
 
   const categoryIcons: Record<string, React.ReactElement> = {
-    "Languages": <Code size={28} className="mr-3 text-purple-400"/>,
-    "Frameworks & Libraries": <Settings2 size={28} className="mr-3 text-purple-400"/>,
-    "AI/ML": <BrainCircuit size={28} className="mr-3 text-purple-400"/>,
-    "Databases": <Database size={28} className="mr-3 text-purple-400"/>,
-    "Frontend": <Palette size={28} className="mr-3 text-purple-400"/>,
-    "Backend & Cloud": <Cloud size={28} className="mr-3 text-purple-400"/>,
-    "Tools": <BriefcaseIcon size={28} className="mr-3 text-purple-400"/>, // Use renamed import
+    "Languages": <Code size={28} className="mr-3 text-accent-orange"/>,
+    "Frameworks & Libraries": <Settings2 size={28} className="mr-3 text-accent-orange"/>,
+    "AI/ML": <BrainCircuit size={28} className="mr-3 text-accent-orange"/>,
+    "Databases": <Database size={28} className="mr-3 text-accent-orange"/>,
+    "Frontend": <Palette size={28} className="mr-3 text-accent-orange"/>,
+    "Backend & Cloud": <Cloud size={28} className="mr-3 text-accent-orange"/>,
+    "Tools": <BriefcaseIcon size={28} className="mr-3 text-accent-orange"/>, // Use renamed import
   };
 
   return (
@@ -59,7 +59,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-green-400 via-emerald-400 to-teal-500" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500" data-cursor-hover-text>
           My Technical Arsenal
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
@@ -75,11 +75,11 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
             className="p-6 md:p-8 bg-white/50 dark:bg-gray-800/30 backdrop-blur-md rounded-xl shadow-2xl border border-gray-700/50"
           >
             <motion.h3 
-              className="text-2xl md:text-3xl font-semibold text-purple-400 mb-6 md:mb-8 flex items-center" 
+              className="text-2xl md:text-3xl font-semibold text-accent-orange mb-6 md:mb-8 flex items-center"
               variants={skillItemVariants} // Animate title as well
               data-cursor-hover-text
             >
-              {categoryIcons[category] || <BriefcaseIcon size={28} className="mr-3 text-purple-400"/>}
+              {categoryIcons[category] || <BriefcaseIcon size={28} className="mr-3 text-accent-orange"/>}
               {category}
             </motion.h3>
             <motion.div 
@@ -89,12 +89,12 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
               {skillsList.map((skill, index) => (
                 <motion.div 
                   key={skill.name} 
-                  className="group relative flex flex-col items-center p-4 bg-white/60 dark:bg-gray-700/50 rounded-lg shadow-lg hover:shadow-purple-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-purple-500"
+                  className="group relative flex flex-col items-center p-4 bg-white/60 dark:bg-gray-700/50 rounded-lg shadow-lg hover:shadow-amber-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-accent-orange"
                   variants={skillItemVariants} 
                   data-cursor-hover-link
                 >
                   {skill.icon && React.cloneElement(skill.icon, { size: 40, className: `mb-3 group-hover:scale-110 transition-transform duration-300 ${skill.icon.props.className || ''}` })}
-                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-purple-500 dark:group-hover:text-purple-300 transition-colors duration-300 text-center">{skill.name}</span>
+                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-accent-orange dark:group-hover:text-amber-300 transition-colors duration-300 text-center">{skill.name}</span>
                   {skill.proficiency && (
                     <div className="w-full h-2.5 bg-gray-600 rounded-full mt-3 overflow-hidden">
                       <motion.div 

--- a/data.tsx
+++ b/data.tsx
@@ -32,21 +32,21 @@ export const personalData: PersonalData = {
       company: "Internpe (Remote)",
       duration: "Jul 2024 - Aug 2024",
       description: "Developed and fine-tuned ML models (Python, TensorFlow, Scikit-learn), improving prediction accuracy by 20%. Optimized preprocessing and feature engineering, reducing training time by 15%. Collaborated on deploying AI/ML solutions, boosting project efficiency.",
-      icon: <Cpu size={24} className="text-purple-400" />
+      icon: <Cpu size={24} className="text-accent-orange" />
     },
      {
       role: "Master of Science in Computer Science",
       company: "University of Oklahoma",
       duration: "Aug 2024 - May 2026 (Expected)",
       description: "Specializing in advanced computer science topics with a focus on AI/ML. Maintained a 4.0 GPA.",
-      icon: <BookOpen size={24} className="text-purple-400" />
+      icon: <BookOpen size={24} className="text-accent-orange" />
     },
     {
       role: "Bachelor of Technology in CSE (Minor in AI/ML)",
       company: "CVR College of Engineering",
       duration: "Aug 2020 - May 2024",
       description: "Comprehensive foundation in Computer Science and Engineering with a specialization in Artificial Intelligence and Machine Learning. Graduated with a 9.1/10.0 GPA.",
-      icon: <Award size={24} className="text-purple-400" />
+      icon: <Award size={24} className="text-accent-orange" />
     },
   ],
   projects: [
@@ -91,14 +91,14 @@ export const personalData: PersonalData = {
     { name: "HTML/CSS", category: "Frontend", icon: <Palette size={24} className="text-pink-400"/>, proficiency: 90 },
     { name: "React.js", category: "Frameworks & Libraries", icon: <Code size={24} className="text-sky-400"/>, proficiency: 90 },
     { name: "Node.js", category: "Frameworks & Libraries", icon: <Server size={24} className="text-green-400"/>, proficiency: 85 },
-    { name: "TensorFlow", category: "AI/ML", icon: <BrainCircuit size={24} className="text-purple-400"/>, proficiency: 80 },
-    { name: "Scikit-learn", category: "AI/ML", icon: <BrainCircuit size={24} className="text-purple-400"/>, proficiency: 85 },
+    { name: "TensorFlow", category: "AI/ML", icon: <BrainCircuit size={24} className="text-accent-orange"/>, proficiency: 80 },
+    { name: "Scikit-learn", category: "AI/ML", icon: <BrainCircuit size={24} className="text-accent-orange"/>, proficiency: 85 },
     { name: "Firebase", category: "Backend & Cloud", icon: <Cloud size={24} className="text-red-400"/>, proficiency: 75 },
     { name: "Google Cloud", category: "Backend & Cloud", icon: <Cloud size={24} className="text-blue-500"/>, proficiency: 70 },
     { name: "Git", category: "Tools", icon: <GitMerge size={24} className="text-gray-400"/>, proficiency: 90 },
     { name: "Kotlin", category: "Languages", icon: <Code size={24} className="text-indigo-400"/>, proficiency: 70 },
     { name: "C", category: "Languages", icon: <Code size={24} className="text-gray-500"/>, proficiency: 75 },
-    { name: "Bootstrap5", category: "Frontend", icon: <Palette size={24} className="text-purple-500"/>, proficiency: 80 },
+    { name: "Bootstrap5", category: "Frontend", icon: <Palette size={24} className="text-accent-orange"/>, proficiency: 80 },
   ],
   contact: {
     intro: "I'm always excited to discuss new projects, innovative ideas, or opportunities to collaborate on something impactful. Whether you have a question or just want to say hi, feel free to reach out!",

--- a/index.html
+++ b/index.html
@@ -8,32 +8,26 @@
     <meta name="description" content="A personal portfolio website for Rohan Mukka, showcasing skills, projects, and experience as an MS Computer Science Student and ML Engineer." />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
+    <link href="https://api.fontshare.com/v2/css?f[]=pp-neue-montreal@400,500,700&display=swap" rel="stylesheet">
     <style>
         html {
             scroll-behavior: smooth;
         }
         :root {
-            --text-color: #1f2937;
-            --gradient-from: #f8fafc;
-            --gradient-to: #e2e8f0;
+            --text-color: #E0E0E0;
+            --background-color: #000000;
         }
         body {
             /* Text styling */
             color: var(--text-color);
-            font-family: 'Inter', sans-serif; /* Default font */
-            background: radial-gradient(circle at center, var(--gradient-from), var(--gradient-to));
-            background-size: 400% 400%;
-            animation: gradient-bg 15s ease infinite;
+            font-family: 'PP Neue Montreal', 'Inter', sans-serif;
+            background-color: var(--background-color);
         }
         body.light {
             --text-color: #1f2937;
-            --gradient-from: #f8fafc;
-            --gradient-to: #e2e8f0;
         }
         body.dark {
             --text-color: #E0E0E0;
-            --gradient-from: #1a1a1a;
-            --gradient-to: #0f0f0f;
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {
@@ -49,8 +43,9 @@
         }
         /* Fallback for non-Webkit if needed, though Tailwind provides utilities for most things */
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Fira+Code:wght@400;500&display=swap');
+        @import url('https://api.fontshare.com/v2/css?f[]=pp-neue-montreal@400,500,700&display=swap');
         body {
-             font-family: 'Inter', sans-serif;
+             font-family: 'PP Neue Montreal', 'Inter', sans-serif;
         }
         .font-mono { /* Use Fira Code for monospaced text */
             font-family: 'Fira Code', monospace;
@@ -66,14 +61,12 @@
             theme: {
                 extend: {
                     fontFamily: {
-                        sans: ['Inter', 'sans-serif'],
+                        sans: ['\'PP Neue Montreal\'', 'Inter', 'sans-serif'],
                         mono: ['Fira Code', 'monospace'],
                     },
                     colors: {
-                        // You can define custom colors here if needed, matching your palette
-                        // Example:
-                        // 'primary-purple': '#8A2BE2',
-                        // 'dark-bg': '#0A0A14',
+                        'dark-bg': '#0A0A14',
+                        'accent-orange': '#FF6B35',
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- import PP Neue Montreal font
- add dark-bg and accent-orange colors in Tailwind config
- set body and section backgrounds to black
- update gradients and accents in all sections and common components
- tweak icons and preloader to use new orange theme

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843063019f4832daf90678e4bb07733