### PR TITLE
Remove orange color scheme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -107,7 +107,7 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen text-inherit selection:bg-accent-orange selection:text-white">
+    <div className="min-h-screen text-inherit selection:bg-black selection:text-white">
       <Navbar
         currentSection={activeSection}
         personalData={{name: personalData.name, resumeUrl: personalData.resumeUrl}}

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.github} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} GitHub Profile`}
           >
@@ -22,7 +22,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.linkedin} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} LinkedIn Profile`}
           >
@@ -30,7 +30,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
           </a>
           <a 
             href={`mailto:${personalData.email}`} 
-            className="text-gray-600 dark:text-gray-400 hover:text-accent-orange dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
             data-cursor-hover-link
             aria-label={`Email ${personalData.name}`}
           >

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -25,13 +25,13 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
   };
 
   const navLinkClasses = (item: string) =>
-    `text-gray-800 dark:text-gray-300 hover:text-accent-orange dark:hover:text-amber-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-accent-orange dark:text-amber-400 font-semibold' : ''}`;
+    `text-gray-800 dark:text-gray-300 hover:text-black dark:hover:text-amber-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-black dark:text-amber-400 font-semibold' : ''}`;
   
   const activeIndicator = (item: string) => 
     currentSection === item.toLowerCase() && (
       <motion.div 
         layoutId="activePill" 
-        className="absolute -bottom-1 left-0 right-0 h-0.5 bg-accent-orange"
+        className="absolute -bottom-1 left-0 right-0 h-0.5 bg-black"
         initial={false} 
         transition={{ type: "spring", stiffness: 350, damping: 30 }} 
       />
@@ -48,10 +48,10 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
         <motion.div
           className="text-3xl font-bold text-gray-900 dark:text-white cursor-pointer"
           onClick={() => handleNavClick('home')}
-          whileHover={{ scale: 1.05, color: '#FF6B35' }}
+          whileHover={{ scale: 1.05, color: '#000000' }}
           data-cursor-hover-link
         >
-          {personalData.name.split(' ')[0]}<span className="text-accent-orange">.</span>
+          {personalData.name.split(' ')[0]}<span className="text-black">.</span>
         </motion.div>
         
         <div className="hidden md:flex space-x-8 items-center">
@@ -71,8 +71,8 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
           <motion.a
             href={personalData.resumeUrl}
             download
-            className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-amber-500/50 transition-all duration-300 transform hover:scale-105"
-            whileHover={{ boxShadow: "0px 0px 15px rgba(255, 107, 53, 0.6)" }}
+            className="bg-gradient-to-r from-black to-gray-700 hover:from-black hover:to-gray-800 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-gray-500/50 transition-all duration-300 transform hover:scale-105"
+            whileHover={{ boxShadow: "0px 0px 15px rgba(0, 0, 0, 0.6)" }}
             data-cursor-hover-link
           >
             Resume
@@ -114,7 +114,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
               <motion.a
                 href={personalData.resumeUrl}
                 download
-                className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
+                className="bg-gradient-to-r from-black to-gray-700 hover:from-black hover:to-gray-800 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
                 data-cursor-hover-link
               >
                 Resume

--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -38,11 +38,11 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
             animate={{ scale: 1, rotateY: 0 }}
             transition={{ duration: 1, type: 'spring', stiffness: 120, delay: 0.2 }}
           >
-            <Layers size={80} className="text-accent-orange filter drop-shadow-[0_0_15px_rgba(255,107,53,0.6)]" />
+            <Layers size={80} className="text-black filter drop-shadow-[0_0_15px_rgba(0,0,0,0.6)]" />
           </motion.div>
           <div className="w-72 h-2.5 bg-gray-700 rounded-full overflow-hidden shadow-inner">
             <motion.div
-              className="h-full bg-accent-orange rounded-full"
+              className="h-full bg-black rounded-full"
               initial={{ width: 0 }}
               animate={{ width: `${progress}%` }}
               transition={{ duration: 0.1, ease: 'linear' }} // Faster bar update

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -43,7 +43,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         variants={titleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-amber-500"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white"
           data-cursor-hover-text
         >
           Discover More About Me
@@ -61,7 +61,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         variants={contentContainerVariants}
       >
         <motion.div className="relative group" variants={imageVariants}>
-          <div className="absolute -inset-0.5 bg-gradient-to-r from-orange-600 to-amber-600 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
+          <div className="absolute -inset-0.5 bg-gradient-to-r from-black to-gray-700 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
           <img 
             src={profileImageUrl} 
             alt={personalData.name} 
@@ -114,8 +114,8 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
            <motion.a 
             href={personalData.resumeUrl} 
             download 
-            className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-amber-500/40 transition-all duration-300 transform hover:scale-105 text-md"
-            whileHover={{ boxShadow: "0px 0px 20px rgba(251, 146, 60, 0.6)" }}
+           className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-black to-gray-700 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-gray-500/40 transition-all duration-300 transform hover:scale-105 text-md"
+           whileHover={{ boxShadow: "0px 0px 20px rgba(0, 0, 0, 0.6)" }}
             whileTap={{ scale: 0.95 }} 
             data-cursor-hover-link 
             variants={paragraphVariants}

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -22,7 +22,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
     { icon: <Mail size={28} className="text-pink-400"/>, label: "Email Me", value: personalData.email, href: `mailto:${personalData.email}` },
     { icon: <Linkedin size={28} className="text-blue-400"/>, label: "Connect on LinkedIn", value: personalData.linkedin.split('/').pop() || personalData.linkedin, href: personalData.linkedin, target: "_blank" },
     { icon: <Github size={28} className="text-gray-500 dark:text-gray-300"/>, label: "View My GitHub", value: personalData.github.split('/').pop() || personalData.github, href: personalData.github, target: "_blank" },
-    { icon: <ListChecks size={28} className="text-orange-400"/>, label: "My LeetCode", value: personalData.leetcode.split('/').pop() || personalData.leetcode, href: personalData.leetcode, target: "_blank" },
+    { icon: <ListChecks size={28} className="text-black"/>, label: "My LeetCode", value: personalData.leetcode.split('/').pop() || personalData.leetcode, href: personalData.leetcode, target: "_blank" },
   ];
   
   return (
@@ -35,7 +35,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white"
           data-cursor-hover-text
         >
           Let's Get In Touch
@@ -60,17 +60,17 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
             initial="hidden"
             whileInView="visible"
             viewport={{ amount: 0.5 }}
-            className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-accent-orange/80 hover:bg-gray-700/60 transition-all duration-300 group"
+            className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-black/80 hover:bg-gray-700/60 transition-all duration-300 group"
             data-cursor-hover-link
           >
             <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-amber-600/50 transition-colors duration-300">
               {method.icon}
             </div>
             <div>
-              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-accent-orange dark:group-hover:text-amber-300 transition-colors duration-300">{method.label}</h4>
+              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-amber-300 transition-colors duration-300">{method.label}</h4>
               <p className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300 transition-colors duration-300 break-all">{method.value}</p>
             </div>
-            <Send size={22} className="ml-auto text-gray-500 group-hover:text-accent-orange transition-all duration-300 transform group-hover:translate-x-1"/>
+            <Send size={22} className="ml-auto text-gray-500 group-hover:text-black transition-all duration-300 transform group-hover:translate-x-1"/>
           </motion.a>
         ))}
       </div>

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -29,7 +29,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-amber-400 via-orange-500 to-red-500"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-amber-400 via-black to-red-500"
           data-cursor-hover-text
         >
           My Journey & Milestones
@@ -60,7 +60,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
             {/* Icon Circle - positioned absolutely relative to this item, then adjusted by margin/padding of content */}
             <div className={`z-10 absolute left-4 md:left-1/2 top-1 transform -translate-x-1/2 
                             ${index % 2 === 0 ? 'md:translate-x-[-50%]' : 'md:translate-x-[-50%]'} 
-                            p-3 bg-amber-600 rounded-full shadow-xl border-2 border-accent-orange flex items-center justify-center`}
+                            p-3 bg-amber-600 rounded-full shadow-xl border-2 border-black flex items-center justify-center`}
             >
               {exp.icon ? React.cloneElement(exp.icon, { size:22, className: `text-white ${exp.icon.props.className || ''}`}) : <Briefcase size={22} className="text-white"/>}
             </div>
@@ -71,8 +71,8 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
 
             {/* Content Card */}
             <div className={`w-full md:w-[calc(50%-2rem)] ${index % 2 === 0 ? 'ml-12 md:ml-8' : 'ml-12 md:mr-8 md:ml-0'} `}>
-              <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-accent-orange/70 transition-colors duration-300">
-                <h3 className="text-xl md:text-2xl font-semibold text-accent-orange mb-1" data-cursor-hover-text>{exp.role}</h3>
+              <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-black/70 transition-colors duration-300">
+                <h3 className="text-xl md:text-2xl font-semibold text-black mb-1" data-cursor-hover-text>{exp.role}</h3>
                 <p className="text-md text-amber-300 mb-2" data-cursor-hover-text>{exp.company}</p>
                 <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 flex items-center" data-cursor-hover-text>
                   <CalendarDays size={14} className="mr-2 text-gray-500"/> {exp.duration}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -52,7 +52,7 @@ const Hero: React.FC<HeroProps> = ({
           transition={{ duration: 25, repeat: Infinity, ease: "easeInOut" }}
         />
         <motion.div
-          className="absolute w-[40vw] h-[40vw] max-w-lg max-h-lg bg-orange-500/20 rounded-full filter blur-3xl opacity-50 bottom-[10%] right-[15%]"
+          className="absolute w-[40vw] h-[40vw] max-w-lg max-h-lg bg-black/20 rounded-full filter blur-3xl opacity-50 bottom-[10%] right-[15%]"
           animate={{
             x: ["10%", "-5%", "10%"],
             y: ["15%", "5%", "15%"],
@@ -100,7 +100,7 @@ const Hero: React.FC<HeroProps> = ({
           data-cursor-hover-text
         >
           Hi, I'm{" "}
-          <span className="bg-clip-text text-transparent bg-gradient-to-r from-orange-400 via-orange-500 to-amber-500">
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white">
             {personalData.name.split(" ")[0]}
           </span>
           <span
@@ -131,7 +131,7 @@ const Hero: React.FC<HeroProps> = ({
         >
           <motion.button
             onClick={() => scrollToSection("projects")}
-            className="px-8 py-3.5 bg-gradient-to-r from-orange-600 to-amber-600 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-amber-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
+            className="px-8 py-3.5 bg-gradient-to-r from-black to-gray-700 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-gray-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
             whileHover={{ boxShadow: "0px 0px 25px rgba(251, 146, 60, 0.6)" }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link
@@ -141,10 +141,10 @@ const Hero: React.FC<HeroProps> = ({
           <motion.a
             href={personalData.resumeUrl}
             download
-            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 border-2 border-accent-orange text-accent-orange font-semibold rounded-xl hover:bg-accent-orange hover:text-white transition-colors duration-300 text-md md:text-lg"
+            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 border-2 border-black text-black font-semibold rounded-xl hover:bg-black hover:text-white transition-colors duration-300 text-md md:text-lg"
             whileHover={{
               scale: 1.05,
-              boxShadow: "0px 0px 15px rgba(255, 107, 53, 0.4)",
+              boxShadow: "0px 0px 15px rgba(0, 0, 0, 0.4)",
             }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -7,7 +7,7 @@ import Section from '../common/Section';
 
 // ProjectCard Component - defined outside Projects to avoid re-creation on parent render
 const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
-  <div className="flex flex-col bg-white/60 dark:bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-accent-orange/70 transition-all duration-300 h-full">
+  <div className="flex flex-col bg-white/60 dark:bg-gray-800/40 backdrop-blur-md rounded-xl shadow-2xl overflow-hidden border border-gray-700/60 group hover:border-black/70 transition-all duration-300 h-full">
     <div className="relative overflow-hidden h-52 md:h-60">
       <img 
         src={project.imageUrl} 
@@ -27,7 +27,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
       )}
     </div>
     <div className="p-6 flex flex-col flex-grow">
-      <h3 className="text-xl md:text-2xl font-semibold text-accent-orange mb-2 group-hover:text-amber-300 transition-colors" data-cursor-hover-text>
+      <h3 className="text-xl md:text-2xl font-semibold text-black mb-2 group-hover:text-amber-300 transition-colors" data-cursor-hover-text>
         {project.title}
       </h3>
       <p className="text-gray-600 dark:text-gray-400 text-sm md:text-base leading-relaxed mb-4 flex-grow" data-cursor-hover-text>
@@ -54,7 +54,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
             href={project.githubUrl} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-accent-orange dark:hover:text-amber-400 transition-colors duration-200"
+            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-amber-400 transition-colors duration-200"
             whileHover={{ scale: 1.05 }} 
             data-cursor-hover-link
           >
@@ -103,7 +103,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white" data-cursor-hover-text>
           My Featured Creations
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -41,13 +41,13 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
   };
 
   const categoryIcons: Record<string, React.ReactElement> = {
-    "Languages": <Code size={28} className="mr-3 text-accent-orange"/>,
-    "Frameworks & Libraries": <Settings2 size={28} className="mr-3 text-accent-orange"/>,
-    "AI/ML": <BrainCircuit size={28} className="mr-3 text-accent-orange"/>,
-    "Databases": <Database size={28} className="mr-3 text-accent-orange"/>,
-    "Frontend": <Palette size={28} className="mr-3 text-accent-orange"/>,
-    "Backend & Cloud": <Cloud size={28} className="mr-3 text-accent-orange"/>,
-    "Tools": <BriefcaseIcon size={28} className="mr-3 text-accent-orange"/>, // Use renamed import
+    "Languages": <Code size={28} className="mr-3 text-black"/>,
+    "Frameworks & Libraries": <Settings2 size={28} className="mr-3 text-black"/>,
+    "AI/ML": <BrainCircuit size={28} className="mr-3 text-black"/>,
+    "Databases": <Database size={28} className="mr-3 text-black"/>,
+    "Frontend": <Palette size={28} className="mr-3 text-black"/>,
+    "Backend & Cloud": <Cloud size={28} className="mr-3 text-black"/>,
+    "Tools": <BriefcaseIcon size={28} className="mr-3 text-black"/>, // Use renamed import
   };
 
   return (
@@ -59,7 +59,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white" data-cursor-hover-text>
           My Technical Arsenal
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>
@@ -75,11 +75,11 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
             className="p-6 md:p-8 bg-white/50 dark:bg-gray-800/30 backdrop-blur-md rounded-xl shadow-2xl border border-gray-700/50"
           >
             <motion.h3 
-              className="text-2xl md:text-3xl font-semibold text-accent-orange mb-6 md:mb-8 flex items-center"
+              className="text-2xl md:text-3xl font-semibold text-black mb-6 md:mb-8 flex items-center"
               variants={skillItemVariants} // Animate title as well
               data-cursor-hover-text
             >
-              {categoryIcons[category] || <BriefcaseIcon size={28} className="mr-3 text-accent-orange"/>}
+              {categoryIcons[category] || <BriefcaseIcon size={28} className="mr-3 text-black"/>}
               {category}
             </motion.h3>
             <motion.div 
@@ -89,12 +89,12 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
               {skillsList.map((skill, index) => (
                 <motion.div 
                   key={skill.name} 
-                  className="group relative flex flex-col items-center p-4 bg-white/60 dark:bg-gray-700/50 rounded-lg shadow-lg hover:shadow-amber-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-accent-orange"
+                  className="group relative flex flex-col items-center p-4 bg-white/60 dark:bg-gray-700/50 rounded-lg shadow-lg hover:shadow-gray-500/30 transition-all duration-300 transform hover:-translate-y-1 border border-gray-600/50 hover:border-black"
                   variants={skillItemVariants} 
                   data-cursor-hover-link
                 >
                   {skill.icon && React.cloneElement(skill.icon, { size: 40, className: `mb-3 group-hover:scale-110 transition-transform duration-300 ${skill.icon.props.className || ''}` })}
-                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-accent-orange dark:group-hover:text-amber-300 transition-colors duration-300 text-center">{skill.name}</span>
+                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-amber-300 transition-colors duration-300 text-center">{skill.name}</span>
                   {skill.proficiency && (
                     <div className="w-full h-2.5 bg-gray-600 rounded-full mt-3 overflow-hidden">
                       <motion.div 

--- a/data.tsx
+++ b/data.tsx
@@ -32,21 +32,21 @@ export const personalData: PersonalData = {
       company: "Internpe (Remote)",
       duration: "Jul 2024 - Aug 2024",
       description: "Developed and fine-tuned ML models (Python, TensorFlow, Scikit-learn), improving prediction accuracy by 20%. Optimized preprocessing and feature engineering, reducing training time by 15%. Collaborated on deploying AI/ML solutions, boosting project efficiency.",
-      icon: <Cpu size={24} className="text-accent-orange" />
+      icon: <Cpu size={24} className="text-black" />
     },
      {
       role: "Master of Science in Computer Science",
       company: "University of Oklahoma",
       duration: "Aug 2024 - May 2026 (Expected)",
       description: "Specializing in advanced computer science topics with a focus on AI/ML. Maintained a 4.0 GPA.",
-      icon: <BookOpen size={24} className="text-accent-orange" />
+      icon: <BookOpen size={24} className="text-black" />
     },
     {
       role: "Bachelor of Technology in CSE (Minor in AI/ML)",
       company: "CVR College of Engineering",
       duration: "Aug 2020 - May 2024",
       description: "Comprehensive foundation in Computer Science and Engineering with a specialization in Artificial Intelligence and Machine Learning. Graduated with a 9.1/10.0 GPA.",
-      icon: <Award size={24} className="text-accent-orange" />
+      icon: <Award size={24} className="text-black" />
     },
   ],
   projects: [
@@ -86,19 +86,19 @@ export const personalData: PersonalData = {
   skills: [
     { name: "Python", category: "Languages", icon: <Code size={24} className="text-yellow-400"/>, proficiency: 95 },
     { name: "JavaScript", category: "Languages", icon: <Code size={24} className="text-yellow-400"/>, proficiency: 90 },
-    { name: "Java", category: "Languages", icon: <Code size={24} className="text-orange-400"/>, proficiency: 80 },
+    { name: "Java", category: "Languages", icon: <Code size={24} className="text-black"/>, proficiency: 80 },
     { name: "SQL", category: "Databases", icon: <Database size={24} className="text-blue-400"/>, proficiency: 85 },
     { name: "HTML/CSS", category: "Frontend", icon: <Palette size={24} className="text-pink-400"/>, proficiency: 90 },
     { name: "React.js", category: "Frameworks & Libraries", icon: <Code size={24} className="text-sky-400"/>, proficiency: 90 },
     { name: "Node.js", category: "Frameworks & Libraries", icon: <Server size={24} className="text-green-400"/>, proficiency: 85 },
-    { name: "TensorFlow", category: "AI/ML", icon: <BrainCircuit size={24} className="text-accent-orange"/>, proficiency: 80 },
-    { name: "Scikit-learn", category: "AI/ML", icon: <BrainCircuit size={24} className="text-accent-orange"/>, proficiency: 85 },
+    { name: "TensorFlow", category: "AI/ML", icon: <BrainCircuit size={24} className="text-black"/>, proficiency: 80 },
+    { name: "Scikit-learn", category: "AI/ML", icon: <BrainCircuit size={24} className="text-black"/>, proficiency: 85 },
     { name: "Firebase", category: "Backend & Cloud", icon: <Cloud size={24} className="text-red-400"/>, proficiency: 75 },
     { name: "Google Cloud", category: "Backend & Cloud", icon: <Cloud size={24} className="text-blue-500"/>, proficiency: 70 },
     { name: "Git", category: "Tools", icon: <GitMerge size={24} className="text-gray-400"/>, proficiency: 90 },
     { name: "Kotlin", category: "Languages", icon: <Code size={24} className="text-indigo-400"/>, proficiency: 70 },
     { name: "C", category: "Languages", icon: <Code size={24} className="text-gray-500"/>, proficiency: 75 },
-    { name: "Bootstrap5", category: "Frontend", icon: <Palette size={24} className="text-accent-orange"/>, proficiency: 80 },
+    { name: "Bootstrap5", category: "Frontend", icon: <Palette size={24} className="text-black"/>, proficiency: 80 },
   ],
   contact: {
     intro: "I'm always excited to discuss new projects, innovative ideas, or opportunities to collaborate on something impactful. Whether you have a question or just want to say hi, feel free to reach out!",

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
                     },
                     colors: {
                         'dark-bg': '#0A0A14',
-                        'accent-orange': '#FF6B35',
+                        'accent-black': '#000000',
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- update Tailwind config to use `accent-black`
- swap orange-themed gradients and accents for black and white
- adjust Preloader, Navbar, Footer, Hero and other sections to use black instead of orange

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430b8778d0832da299651237e6f196