### PR TITLE
Remove leftover orange/amber styles

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.github} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-black transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} GitHub Profile`}
           >
@@ -22,7 +22,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
             href={personalData.linkedin} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-black transition-colors"
             data-cursor-hover-link
             aria-label={`${personalData.name} LinkedIn Profile`}
           >
@@ -30,7 +30,7 @@ const Footer: React.FC<FooterProps> = ({ personalData }) => {
           </a>
           <a 
             href={`mailto:${personalData.email}`} 
-            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-amber-400 transition-colors"
+            className="text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-black transition-colors"
             data-cursor-hover-link
             aria-label={`Email ${personalData.name}`}
           >

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
   };
 
   const navLinkClasses = (item: string) =>
-    `text-gray-800 dark:text-gray-300 hover:text-black dark:hover:text-amber-400 transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-black dark:text-amber-400 font-semibold' : ''}`;
+    `text-gray-800 dark:text-gray-300 hover:text-black dark:hover:text-black transition-colors duration-200 relative group ${currentSection === item.toLowerCase() ? 'text-black dark:text-black font-semibold' : ''}`;
   
   const activeIndicator = (item: string) => 
     currentSection === item.toLowerCase() && (

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -95,7 +95,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
           ))}
           {strengths && strengths.length > 0 && (
             <motion.div className="mt-8 pt-6 border-t border-gray-700/50" variants={paragraphVariants}>
-              <h4 className="text-xl font-semibold text-amber-300 mb-4" data-cursor-hover-text>Core Strengths:</h4>
+              <h4 className="text-xl font-semibold text-gray-300 mb-4" data-cursor-hover-text>Core Strengths:</h4>
               <motion.ul className="space-y-3" variants={contentContainerVariants}> {/* Stagger children for list items */}
                 {strengths.map((strength, index) => (
                   <motion.li 

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -63,11 +63,11 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
             className="flex items-center p-5 md:p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-md rounded-xl shadow-xl border border-gray-700/70 hover:border-black/80 hover:bg-gray-700/60 transition-all duration-300 group"
             data-cursor-hover-link
           >
-            <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-amber-600/50 transition-colors duration-300">
+            <div className="mr-5 p-3 bg-white/50 dark:bg-gray-700/50 rounded-lg shadow-md group-hover:bg-gray-700/50 transition-colors duration-300">
               {method.icon}
             </div>
             <div>
-              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-amber-300 transition-colors duration-300">{method.label}</h4>
+              <h4 className="text-lg md:text-xl font-semibold text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-gray-300 transition-colors duration-300">{method.label}</h4>
               <p className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300 transition-colors duration-300 break-all">{method.value}</p>
             </div>
             <Send size={22} className="ml-auto text-gray-500 group-hover:text-black transition-all duration-300 transform group-hover:translate-x-1"/>

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -29,7 +29,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-amber-400 via-black to-red-500"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-gray-400 via-gray-600 to-gray-200"
           data-cursor-hover-text
         >
           My Journey & Milestones
@@ -58,9 +58,9 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
                         ${index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'}`} // Alternating sides on desktop
           >
             {/* Icon Circle - positioned absolutely relative to this item, then adjusted by margin/padding of content */}
-            <div className={`z-10 absolute left-4 md:left-1/2 top-1 transform -translate-x-1/2 
-                            ${index % 2 === 0 ? 'md:translate-x-[-50%]' : 'md:translate-x-[-50%]'} 
-                            p-3 bg-amber-600 rounded-full shadow-xl border-2 border-black flex items-center justify-center`}
+            <div className={`z-10 absolute left-4 md:left-1/2 top-1 transform -translate-x-1/2
+                            ${index % 2 === 0 ? 'md:translate-x-[-50%]' : 'md:translate-x-[-50%]'}
+                            p-3 bg-gray-700 rounded-full shadow-xl border-2 border-black flex items-center justify-center`}
             >
               {exp.icon ? React.cloneElement(exp.icon, { size:22, className: `text-white ${exp.icon.props.className || ''}`}) : <Briefcase size={22} className="text-white"/>}
             </div>
@@ -73,7 +73,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
             <div className={`w-full md:w-[calc(50%-2rem)] ${index % 2 === 0 ? 'ml-12 md:ml-8' : 'ml-12 md:mr-8 md:ml-0'} `}>
               <div className="p-6 bg-white/60 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl shadow-xl border border-gray-700 hover:border-black/70 transition-colors duration-300">
                 <h3 className="text-xl md:text-2xl font-semibold text-black mb-1" data-cursor-hover-text>{exp.role}</h3>
-                <p className="text-md text-amber-300 mb-2" data-cursor-hover-text>{exp.company}</p>
+                <p className="text-md text-gray-300 mb-2" data-cursor-hover-text>{exp.company}</p>
                 <p className="text-xs text-gray-600 dark:text-gray-400 mb-3 flex items-center" data-cursor-hover-text>
                   <CalendarDays size={14} className="mr-2 text-gray-500"/> {exp.duration}
                 </p>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -43,7 +43,7 @@ const Hero: React.FC<HeroProps> = ({
       <div className="absolute inset-0 overflow-hidden z-0">
         {/* Using Tailwind arbitrary values for positioning percentages */}
         <motion.div
-          className="absolute w-[50vw] h-[50vw] max-w-xl max-h-xl bg-amber-600/20 rounded-full filter blur-3xl opacity-60 top-[5%] left-[10%]"
+          className="absolute w-[50vw] h-[50vw] max-w-xl max-h-xl bg-black/20 rounded-full filter blur-3xl opacity-60 top-[5%] left-[10%]"
           animate={{
             x: ["-10%", "10%", "-10%"],
             y: ["-10%", "0%", "-10%"],
@@ -66,7 +66,7 @@ const Hero: React.FC<HeroProps> = ({
           }}
         />
         <motion.div
-          className="absolute w-[30vw] h-[30vw] max-w-md max-h-md bg-amber-500/15 rounded-full filter blur-2xl opacity-40 top-1/2 left-[45%] -translate-x-1/2 -translate-y-1/2"
+          className="absolute w-[30vw] h-[30vw] max-w-md max-h-md bg-black/10 rounded-full filter blur-2xl opacity-40 top-1/2 left-[45%] -translate-x-1/2 -translate-y-1/2"
           animate={{
             x: ["0%", "5%", "-5%", "0%"],
             y: ["-5%", "10%", "0%", "-5%"],
@@ -132,7 +132,7 @@ const Hero: React.FC<HeroProps> = ({
           <motion.button
             onClick={() => scrollToSection("projects")}
             className="px-8 py-3.5 bg-gradient-to-r from-black to-gray-700 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-gray-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
-            whileHover={{ boxShadow: "0px 0px 25px rgba(251, 146, 60, 0.6)" }}
+            whileHover={{ boxShadow: "0px 0px 25px rgba(0, 0, 0, 0.6)" }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link
           >

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -27,7 +27,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
       )}
     </div>
     <div className="p-6 flex flex-col flex-grow">
-      <h3 className="text-xl md:text-2xl font-semibold text-black mb-2 group-hover:text-amber-300 transition-colors" data-cursor-hover-text>
+      <h3 className="text-xl md:text-2xl font-semibold text-black mb-2 group-hover:text-gray-300 transition-colors" data-cursor-hover-text>
         {project.title}
       </h3>
       <p className="text-gray-600 dark:text-gray-400 text-sm md:text-base leading-relaxed mb-4 flex-grow" data-cursor-hover-text>
@@ -39,10 +39,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
         </p>
       )}
       <div className="mb-4">
-        <p className="text-xs text-amber-300 mb-1 font-medium">Technologies Used:</p>
+        <p className="text-xs text-gray-300 mb-1 font-medium">Technologies Used:</p>
         <div className="flex flex-wrap gap-2">
           {project.tags.map(tag => (
-            <span key={tag} className="px-2.5 py-1 text-xs bg-amber-700/50 text-amber-200 rounded-full shadow-sm">
+            <span key={tag} className="px-2.5 py-1 text-xs bg-gray-700/50 text-gray-200 rounded-full shadow-sm">
               {tag}
             </span>
           ))}
@@ -54,7 +54,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
             href={project.githubUrl} 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-amber-400 transition-colors duration-200"
+            className="inline-flex items-center text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-black transition-colors duration-200"
             whileHover={{ scale: 1.05 }} 
             data-cursor-hover-link
           >

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -35,7 +35,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
 
   const getProficiencyColor = (level: number): string => {
     if (level >= 90) return "bg-green-500";
-    if (level >= 75) return "bg-amber-500";
+    if (level >= 75) return "bg-gray-500";
     if (level >= 60) return "bg-yellow-500";
     return "bg-red-500";
   };
@@ -94,7 +94,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
                   data-cursor-hover-link
                 >
                   {skill.icon && React.cloneElement(skill.icon, { size: 40, className: `mb-3 group-hover:scale-110 transition-transform duration-300 ${skill.icon.props.className || ''}` })}
-                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-amber-300 transition-colors duration-300 text-center">{skill.name}</span>
+                  <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-gray-300 transition-colors duration-300 text-center">{skill.name}</span>
                   {skill.proficiency && (
                     <div className="w-full h-2.5 bg-gray-600 rounded-full mt-3 overflow-hidden">
                       <motion.div 


### PR DESCRIPTION
## Summary
- swap remaining amber backgrounds in Hero for grayscale
- replace amber gradient and accents in Experience timeline with grayscale
- convert amber hover styles to gray in Contact and Projects sections
- update skill progress colors to gray and grayscale group-hover text
- adjust navbar and footer hover states to black text
- turn 'Core Strengths' heading gray

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430e2e5094832da3f33f9cf22da763