### PR TITLE
Add theme toggle and radial background

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,12 @@ import Footer from './components/common/Footer';
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [activeSection, setActiveSection] = useState('home');
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as 'light' | 'dark') || 'dark';
+    }
+    return 'dark';
+  });
 
   const homeRef = useRef<HTMLElement | null>(null);
   const aboutRef = useRef<HTMLElement | null>(null);
@@ -76,13 +82,13 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]); // Re-run when isLoading changes to attach observer after preloader
 
-  // Force dark theme on mount
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.body.classList.add('dark');
-      document.body.classList.remove('light');
+      document.body.classList.toggle('dark', theme === 'dark');
+      document.body.classList.toggle('light', theme === 'light');
+      localStorage.setItem('theme', theme);
     }
-  }, []);
+  }, [theme]);
 
   const scrollToSection = (id: string) => {
     const sectionRef = sectionRefs[id];
@@ -101,6 +107,10 @@ const App: React.FC = () => {
     }
   };
 
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
 
   if (isLoading && typeof window !== 'undefined') { // Ensure window check for SSR safety, though not strictly needed for CSR
     return <Preloader onLoaded={handlePreloaderLoaded} />;
@@ -112,6 +122,8 @@ const App: React.FC = () => {
         currentSection={activeSection}
         personalData={{name: personalData.name, resumeUrl: personalData.resumeUrl}}
         scrollToSection={scrollToSection}
+        theme={theme}
+        toggleTheme={toggleTheme}
       />
       
       <main>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the source code for my personal portfolio website. It i
 
 - Responsive layout built with [Tailwind CSS](https://tailwindcss.com/) and React components.
 - Animated sections including a typewriter effect (`useTypewriter` hook) and Lottie animations.
+- Optional light/dark theme toggle with animated radial background.
 - Data-driven design using `data.tsx` and typed interfaces in `types.ts`.
 - Simple configuration via `vite.config.ts` with support for environment variables.
 

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -1,13 +1,13 @@
 
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, Sun, Moon } from 'lucide-react';
 import { NavbarProps } from '../../types';
 
 const NAV_ITEMS = ["Home", "About", "Skills", "Projects", "Experience", "Contact"];
 
 
-const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToSection }) => {
+const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToSection, theme, toggleTheme }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
 
@@ -56,11 +56,11 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
         
         <div className="hidden md:flex space-x-8 items-center">
           {NAV_ITEMS.map((item) => (
-            <motion.button 
-              key={item} 
-              onClick={() => handleNavClick(item)} 
+            <motion.button
+              key={item}
+              onClick={() => handleNavClick(item)}
               className={navLinkClasses(item)}
-              whileHover={{ y: -2 }} 
+              whileHover={{ y: -2 }}
               whileTap={{ y: 0 }}
               data-cursor-hover-link
             >
@@ -68,6 +68,14 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
               {activeIndicator(item)}
             </motion.button>
           ))}
+          <button
+            onClick={toggleTheme}
+            className="text-gray-900 dark:text-white focus:outline-none"
+            aria-label="Toggle theme"
+            data-cursor-hover-link
+          >
+            {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+          </button>
           <motion.a
             href={personalData.resumeUrl}
             download
@@ -102,15 +110,23 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
           >
             <div className="flex flex-col items-center py-6 space-y-5">
               {NAV_ITEMS.map((item) => (
-                <button 
-                  key={item} 
-                  onClick={() => handleNavClick(item)} 
+                <button
+                  key={item}
+                  onClick={() => handleNavClick(item)}
                   className={`text-xl py-2 ${navLinkClasses(item)}`}
                   data-cursor-hover-link
                 >
                   {item}
                 </button>
               ))}
+              <button
+                onClick={toggleTheme}
+                className="text-gray-900 dark:text-white focus:outline-none"
+                aria-label="Toggle theme"
+                data-cursor-hover-link
+              >
+                {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+              </button>
               <motion.a
                 href={personalData.resumeUrl}
                 download

--- a/components/common/Section.tsx
+++ b/components/common/Section.tsx
@@ -7,7 +7,7 @@ const Section: React.FC<SectionProps> = ({ children, id, className = '', fullHei
     <motion.section
       ref={refProp}
       id={id}
-      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-200 dark:text-gray-100 bg-black ${className}`}
+      className={`relative ${fullHeight ? 'min-h-screen' : 'py-24 md:py-32'} px-6 md:px-12 text-gray-200 dark:text-gray-100 bg-transparent ${className}`}
       data-testid={`section-${id}`} // For testing
     >
       <div className={`container mx-auto relative z-10 

--- a/index.html
+++ b/index.html
@@ -15,19 +15,27 @@
         }
         :root {
             --text-color: #E0E0E0;
-            --background-color: #000000;
+            --gradient-start: #1a1a1a;
+            --gradient-end: #0f0f0f;
         }
         body {
             /* Text styling */
             color: var(--text-color);
             font-family: 'PP Neue Montreal', 'Inter', sans-serif;
-            background-color: var(--background-color);
+            background: radial-gradient(circle at top left, var(--gradient-start), var(--gradient-end));
+            background-attachment: fixed;
+            background-size: 200% 200%;
+            animation: gradient-bg 30s ease infinite;
         }
         body.light {
             --text-color: #1f2937;
+            --gradient-start: #f8fafc;
+            --gradient-end: #e2e8f0;
         }
         body.dark {
             --text-color: #E0E0E0;
+            --gradient-start: #1a1a1a;
+            --gradient-end: #0f0f0f;
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {

--- a/types.ts
+++ b/types.ts
@@ -80,6 +80,8 @@ export interface NavbarProps {
   currentSection: string;
   personalData: Pick<PersonalData, 'name' | 'resumeUrl'>;
   scrollToSection: (id: string) => void;
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
 export interface HeroProps {


### PR DESCRIPTION
## Summary
- improve styling with a radial gradient background
- allow switching between dark and light themes
- expose theme props in `Navbar` and toggle button
- update README with new feature

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684373921bd0832db6add8dde86fcac7