### PR TITLE
Enhance portfolio color scheme

### DIFF
--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -79,7 +79,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
           <motion.a
             href={personalData.resumeUrl}
             download
-            className="bg-gradient-to-r from-black to-gray-700 hover:from-black hover:to-gray-800 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-gray-500/50 transition-all duration-300 transform hover:scale-105"
+            className="bg-gradient-to-r from-purple-600 to-pink-500 hover:from-purple-700 hover:to-pink-600 text-white font-semibold px-5 py-2.5 rounded-lg shadow-lg hover:shadow-pink-500/50 transition-all duration-300 transform hover:scale-105"
             whileHover={{ boxShadow: "0px 0px 15px rgba(0, 0, 0, 0.6)" }}
             data-cursor-hover-link
           >
@@ -130,7 +130,7 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
               <motion.a
                 href={personalData.resumeUrl}
                 download
-                className="bg-gradient-to-r from-black to-gray-700 hover:from-black hover:to-gray-800 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
+                className="bg-gradient-to-r from-purple-600 to-pink-500 hover:from-purple-700 hover:to-pink-600 text-white font-semibold px-8 py-3 rounded-lg shadow-md mt-3 text-lg"
                 data-cursor-hover-link
               >
                 Resume

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -43,7 +43,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         variants={titleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400"
           data-cursor-hover-text
         >
           Discover More About Me
@@ -61,7 +61,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
         variants={contentContainerVariants}
       >
         <motion.div className="relative group" variants={imageVariants}>
-          <div className="absolute -inset-0.5 bg-gradient-to-r from-black to-gray-700 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
+          <div className="absolute -inset-0.5 bg-gradient-to-r from-purple-700 to-pink-600 rounded-xl blur opacity-50 group-hover:opacity-75 transition duration-1000 group-hover:duration-200 animate-tilt"></div>
           <img 
             src={profileImageUrl} 
             alt={personalData.name} 
@@ -114,7 +114,7 @@ const About: React.FC<AboutProps> = ({ refProp, personalData }) => {
            <motion.a 
             href={personalData.resumeUrl} 
             download 
-           className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-black to-gray-700 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-gray-500/40 transition-all duration-300 transform hover:scale-105 text-md"
+           className="mt-8 inline-flex items-center px-7 py-3 bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl hover:shadow-pink-500/40 transition-all duration-300 transform hover:scale-105 text-md"
            whileHover={{ boxShadow: "0px 0px 20px rgba(0, 0, 0, 0.6)" }}
             whileTap={{ scale: 0.95 }} 
             data-cursor-hover-link 

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -35,7 +35,7 @@ const Contact: React.FC<ContactProps> = ({ refProp, personalData }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400"
           data-cursor-hover-text
         >
           Let's Get In Touch

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -29,7 +29,7 @@ const Experience: React.FC<ExperienceProps> = ({ refProp, experience }) => {
         variants={sectionTitleVariants}
       >
         <h2
-          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-gray-400 via-gray-600 to-gray-200"
+          className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400"
           data-cursor-hover-text
         >
           My Journey & Milestones

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -100,7 +100,7 @@ const Hero: React.FC<HeroProps> = ({
           data-cursor-hover-text
         >
           Hi, I'm{" "}
-          <span className="bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white">
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400">
             {personalData.name.split(" ")[0]}
           </span>
           <span
@@ -131,7 +131,7 @@ const Hero: React.FC<HeroProps> = ({
         >
           <motion.button
             onClick={() => scrollToSection("projects")}
-            className="px-8 py-3.5 bg-gradient-to-r from-black to-gray-700 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-gray-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
+            className="px-8 py-3.5 bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:shadow-pink-500/40 transition-all duration-300 transform hover:scale-105 text-md md:text-lg"
             whileHover={{ boxShadow: "0px 0px 25px rgba(0, 0, 0, 0.6)" }}
             whileTap={{ scale: 0.95 }}
             data-cursor-hover-link

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -103,7 +103,7 @@ const Projects: React.FC<ProjectsProps> = ({ refProp, projects }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400" data-cursor-hover-text>
           My Featured Creations
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -59,7 +59,7 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
         viewport={{ once: true, amount: 0.3 }} 
         variants={sectionTitleVariants}
       >
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-black via-gray-600 to-white" data-cursor-hover-text>
+        <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400" data-cursor-hover-text>
           My Technical Arsenal
         </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-cursor-hover-text>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
         }
         :root {
             --text-color: #E0E0E0;
-            --gradient-start: #1a1a1a;
-            --gradient-end: #0f0f0f;
+            --gradient-start: #32175e;
+            --gradient-end: #0f172a;
         }
         body {
             /* Text styling */
@@ -29,13 +29,13 @@
         }
         body.light {
             --text-color: #1f2937;
-            --gradient-start: #f8fafc;
-            --gradient-end: #e2e8f0;
+            --gradient-start: #e0f2fe;
+            --gradient-end: #fdf2f8;
         }
         body.dark {
             --text-color: #E0E0E0;
-            --gradient-start: #1a1a1a;
-            --gradient-end: #0f0f0f;
+            --gradient-start: #32175e;
+            --gradient-end: #0f172a;
         }
         /* Custom scrollbar for Webkit browsers */
         body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- tweak base gradient colors in `index.html`
- switch gradients in headings and buttons to a purple/pink palette

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843846bf420832dbb333ff2c9fc4671