### PR TITLE
Fix greeting spacing and emoji alignment

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -96,15 +96,15 @@ const Hero: React.FC<HeroProps> = ({
         </motion.div>
         <motion.h1
           variants={itemVariants}
-          className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-extrabold mb-3 md:mb-4 leading-tight"
+          className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-extrabold mb-3 md:mb-4 leading-tight inline-flex items-center"
           data-cursor-hover-text
         >
-          Hi, I'm{" "}
-          <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400">
+          <span className="mr-2">Hi, I'm</span>
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-pink-500 to-red-400 mr-2">
             {personalData.name.split(" ")[0]}
           </span>
           <span
-            className="wave-emoji ml-2 md:ml-3 text-3xl md:text-4xl lg:text-5xl"
+            className="wave-emoji ml-2 md:ml-3 text-3xl md:text-4xl lg:text-5xl align-middle"
             role="img"
             aria-label="waving hand"
           >


### PR DESCRIPTION
## Summary
- space out the greeting text and keep the wave emoji on the same line

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68438fd6f22c832d8b2a52bc733483e6