### PR TITLE
Reorder Projects before Skills

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,16 +18,16 @@ const App: React.FC = () => {
 
   const homeRef = useRef<HTMLElement | null>(null);
   const aboutRef = useRef<HTMLElement | null>(null);
-  const skillsRef = useRef<HTMLElement | null>(null);
   const projectsRef = useRef<HTMLElement | null>(null);
+  const skillsRef = useRef<HTMLElement | null>(null);
   const experienceRef = useRef<HTMLElement | null>(null);
   const contactRef = useRef<HTMLElement | null>(null);
 
   const sectionRefs: Record<string, React.RefObject<HTMLElement | null>> = {
     home: homeRef,
     about: aboutRef,
-    skills: skillsRef,
     projects: projectsRef,
+    skills: skillsRef,
     experience: experienceRef,
     contact: contactRef,
   };
@@ -121,8 +121,8 @@ const App: React.FC = () => {
             typewriterWords={typewriterWords}
         />
         <About refProp={aboutRef} personalData={{name: personalData.name, about: personalData.about, resumeUrl: personalData.resumeUrl}} />
-        <Skills refProp={skillsRef} skills={personalData.skills} />
         <Projects refProp={projectsRef} projects={personalData.projects} />
+        <Skills refProp={skillsRef} skills={personalData.skills} />
         <Experience refProp={experienceRef} experience={personalData.experience} />
         <Contact refProp={contactRef} personalData={{email: personalData.email, linkedin: personalData.linkedin, github: personalData.github, leetcode: personalData.leetcode, contact: personalData.contact}} />
       </main>

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Menu, X } from 'lucide-react';
 import { NavbarProps } from '../../types';
 
-const NAV_ITEMS = ["Home", "About", "Skills", "Projects", "Experience", "Contact"];
+const NAV_ITEMS = ["Home", "About", "Projects", "Skills", "Experience", "Contact"];
 
 
 const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToSection }) => {


### PR DESCRIPTION
## Summary
- move Projects section before Skills in App layout
- update navigation order accordingly

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843b1b68680832dad85c6014957ad0b