### PR TITLE
Fix overlay color for preloader

### DIFF
--- a/components/common/Preloader.tsx
+++ b/components/common/Preloader.tsx
@@ -10,8 +10,7 @@ const Preloader: React.FC<PreloaderProps> = ({ onLoaded }) => {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center z-[10000]"
-      style={{ backgroundColor: 'var(--background-color)' }}
+      className="fixed inset-0 flex items-center justify-center z-[10000] bg-transparent"
     >
       <div className="loader4">
         <svg viewBox="25 25 50 50">

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ const Hero: React.FC<HeroProps> = ({
     hidden: { opacity: 0 },
     visible: {
       opacity: 1,
-      transition: { staggerChildren: 0.2, delayChildren: 0.8 },
+      transition: { staggerChildren: 0.2, delayChildren: 0 },
     },
   };
   const itemVariants = {


### PR DESCRIPTION
## Summary
- remove undefined CSS variable from the Preloader overlay so no black shade is shown
- reduce Hero section delay so content appears immediately

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843c7b5adb4832dab7fe2439c1c8df4