### PR TITLE
Remove progress bar from skills

### DIFF
--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -33,12 +33,6 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
     visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.4, ease: "easeOut" } } 
   };
 
-  const getProficiencyColor = (level: number): string => {
-    if (level >= 90) return "bg-green-500";
-    if (level >= 75) return "bg-gray-500";
-    if (level >= 60) return "bg-yellow-500";
-    return "bg-red-500";
-  };
 
   const categoryIcons: Record<string, React.ReactElement> = {
     "Languages": <Code size={28} className="mr-3 text-yellow-400" />,
@@ -95,17 +89,6 @@ const Skills: React.FC<SkillsProps> = ({ refProp, skills }) => {
                 >
                   {skill.icon && React.cloneElement(skill.icon, { size: 40, className: `mb-3 group-hover:scale-110 transition-transform duration-300 ${skill.icon.props.className || ''}` })}
                   <span className="text-md md:text-lg font-medium text-gray-800 dark:text-gray-200 group-hover:text-black dark:group-hover:text-gray-300 transition-colors duration-300 text-center">{skill.name}</span>
-                  {skill.proficiency && (
-                    <div className="w-full h-2.5 bg-gray-600 rounded-full mt-3 overflow-hidden">
-                      <motion.div 
-                        className={`h-full rounded-full ${getProficiencyColor(skill.proficiency)}`}
-                        initial={{ width: 0 }}
-                        whileInView={{ width: `${skill.proficiency}%` }}
-                        viewport={{ once: true, amount: 0.8 }}
-                        transition={{ duration: 0.8, ease: "easeOut", delay: 0.2 + index * 0.05 }}
-                      />
-                    </div>
-                  )}
                 </motion.div>
               ))}
             </motion.div>


### PR DESCRIPTION
## Summary
- remove proficiency bar visuals from skills section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844b0453dc0832db581419abc25db64