### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect, useRef } from 'react';
+import { useTheme } from './hooks/useTheme';
 import { personalData, typewriterWords } from './data';
 
 import Navbar from './components/common/Navbar';
@@ -15,6 +16,7 @@ import Footer from './components/common/Footer';
 const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [activeSection, setActiveSection] = useState('home');
+  const { theme, toggleTheme } = useTheme();
 
   const homeRef = useRef<HTMLElement | null>(null);
   const aboutRef = useRef<HTMLElement | null>(null);
@@ -76,22 +78,6 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]); // Re-run when isLoading changes to attach observer after preloader
 
-  useEffect(() => {
-    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      const media = window.matchMedia('(prefers-color-scheme: dark)');
-
-      const applyTheme = (isDark: boolean) => {
-        document.body.classList.toggle('dark', isDark);
-        document.body.classList.toggle('light', !isDark);
-      };
-
-      applyTheme(media.matches);
-
-      const handler = (e: MediaQueryListEvent) => applyTheme(e.matches);
-      media.addEventListener('change', handler);
-      return () => media.removeEventListener('change', handler);
-    }
-  }, []);
 
   const scrollToSection = (id: string) => {
     const sectionRef = sectionRefs[id];
@@ -122,6 +108,8 @@ const App: React.FC = () => {
         currentSection={activeSection}
         personalData={{name: personalData.name, resumeUrl: personalData.resumeUrl}}
         scrollToSection={scrollToSection}
+        theme={theme}
+        toggleTheme={toggleTheme}
       />
       
       <main>

--- a/components/common/Navbar.tsx
+++ b/components/common/Navbar.tsx
@@ -1,13 +1,13 @@
 
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, Sun, Moon } from 'lucide-react';
 import { NavbarProps } from '../../types';
 
 const NAV_ITEMS = ["Home", "About", "Projects", "Skills", "Experience", "Contact"];
 
 
-const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToSection }) => {
+const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToSection, theme, toggleTheme }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
 
@@ -78,6 +78,14 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
           >
             Resume
           </motion.a>
+          <button
+            onClick={toggleTheme}
+            className="text-gray-800 dark:text-gray-300 hover:text-purple-600 dark:hover:text-pink-400 focus:outline-none"
+            aria-label="Toggle theme"
+            data-cursor-hover-link
+          >
+            {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+          </button>
         </div>
 
         <div className="md:hidden">
@@ -120,6 +128,14 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, personalData, scrollToS
               >
                 Resume
               </motion.a>
+              <button
+                onClick={toggleTheme}
+                className="text-gray-800 dark:text-gray-300 hover:text-purple-600 dark:hover:text-pink-400 focus:outline-none"
+                aria-label="Toggle theme"
+                data-cursor-hover-link
+              >
+                {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+              </button>
             </div>
           </motion.div>
         )}

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export const useTheme = (): { theme: Theme; toggleTheme: () => void } => {
+  const getInitialTheme = (): Theme => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') {
+        return stored;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return 'light';
+  };
+
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.body.classList.toggle('dark', theme === 'dark');
+      document.body.classList.toggle('light', theme === 'light');
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return { theme, toggleTheme };
+};

--- a/types.ts
+++ b/types.ts
@@ -80,6 +80,8 @@ export interface NavbarProps {
   currentSection: string;
   personalData: Pick<PersonalData, 'name' | 'resumeUrl'>;
   scrollToSection: (id: string) => void;
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
 export interface HeroProps {


### PR DESCRIPTION
## Summary
- manage theme with a new `useTheme` hook
- add theme toggle button to the navbar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844b8aab940832dbd2b93ceab613ce1