### PR TITLE
Add scroll down arrow in hero

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Download } from "lucide-react";
+import { Download, ChevronDown } from "lucide-react";
 import { HeroProps } from "../../types";
 import Section from "../common/Section";
 //import InfinitySymbol from "../common/InfinitySymbol";
@@ -112,11 +112,19 @@ const Hero: React.FC<HeroProps> = ({
           </motion.a>
         </motion.div>
       </motion.div>
+      <motion.button
+        onClick={() => scrollToSection("about")}
+        className="absolute bottom-6 left-1/2 -translate-x-1/2 p-2 text-gray-800 dark:text-gray-200 animate-bounce"
+        whileHover={{ scale: 1.1 }}
+        aria-label="Scroll down"
+      >
+        <ChevronDown size={32} />
+      </motion.button>
       {/* Wave animation style tag - Tailwind doesn't directly support keyframes without config */}
       <style>{`
-        .wave-emoji { 
-          display: inline-block; 
-          animation: wave-animation 2.5s infinite; 
+        .wave-emoji {
+          display: inline-block;
+          animation: wave-animation 2.5s infinite;
           transform-origin: 70% 70%; 
         } 
         @keyframes wave-animation { 


### PR DESCRIPTION
## Summary
- show an animated ChevronDown button at the bottom of the Hero section
- clicking it scrolls to the About section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df67dcf74832d8c73dfee724cf782