### PR TITLE
Fix hero arrow color in light mode

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -113,20 +113,20 @@ const Hero: React.FC<HeroProps> = ({
         </motion.div>
         <motion.button
           onClick={() => scrollToSection("about")}
-          className="mt-8 md:mt-10 p-2 text-gray-800 dark:text-gray-200 animate-bounce"
+          className="mt-8 md:mt-10 p-2 animate-bounce"
           whileHover={{ scale: 1.1 }}
           aria-label="Scroll down"
         >
-          <ChevronDown size={32} />
+          <ChevronDown size={32} className="text-gray-800 dark:text-gray-200" />
         </motion.button>
       </motion.div>
       <motion.button
         onClick={() => scrollToSection("about")}
-        className="absolute bottom-8 left-1/2 -translate-x-1/2 p-2 text-gray-800 dark:text-gray-200 animate-bounce"
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 p-2 animate-bounce"
         whileHover={{ scale: 1.1 }}
         aria-label="Scroll down"
       >
-        <ChevronDown size={32} />
+        <ChevronDown size={32} className="text-gray-800 dark:text-gray-200" />
       </motion.button>
       {/* Wave animation style tag - Tailwind doesn't directly support keyframes without config */}
       <style>{`


### PR DESCRIPTION
## Summary
- explicitly set arrow icon colors in Hero section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e0136bbcc832d8e15d76248b75663