### PR TITLE
Fix light mode readability issues

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -114,7 +114,7 @@ const Hero: React.FC<HeroProps> = ({
         <motion.button
 
   onClick={() => scrollToSection("about")}
-  className="mt-10 md:mt-40 p-2 text-black dark:text-gray-200 animate-bounce opacity-80 hover:opacity-100"
+  className="mt-10 md:mt-40 p-2 text-gray-700 dark:text-gray-200 animate-bounce opacity-80 hover:opacity-100"
   whileHover={{ scale: 1.1 }}
   aria-label="Scroll down"
 >

--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
         }
         body {
             /* Text styling */
-            color: var(--text-color);
             font-family: 'PP Neue Montreal', 'Inter', sans-serif;
             background: radial-gradient(circle at top left, var(--gradient-start), var(--gradient-end));
             background-attachment: fixed;
@@ -117,7 +116,7 @@
 }
 </script>
 </head>
-<body class="min-h-screen">
+<body class="min-h-screen text-gray-800 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- improve readability in light mode by removing body color override
- update light mode base text color
- ensure scroll arrow shows against light background

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e215bc700832d998cf86623cdd7dd