### PR TITLE
Replace dead counterapi view counter with self-hosted Upstash counter

### DIFF
--- a/api/views.ts
+++ b/api/views.ts
@@ -1,0 +1,59 @@
+import { Redis } from "@upstash/redis";
+
+/**
+ * Page view counter, backed by Upstash Redis.
+ *
+ * Replaces counterapi.dev, whose v1 API was retired and now returns 410 for
+ * every request. The credentials live in Vercel environment variables and are
+ * only ever read here, on the server, so nothing sensitive reaches the bundle.
+ *
+ *   GET  /api/views  -> read the count without changing it
+ *   POST /api/views  -> increment, then return the new count
+ */
+
+const KEY = "portfolio:views";
+
+/** Carried over from the retired counterapi counter, which last read 333. */
+const SEED = 333;
+
+interface ApiRequest {
+  method?: string;
+}
+
+interface ApiResponse {
+  status(code: number): ApiResponse;
+  json(body: unknown): void;
+  setHeader(name: string, value: string): void;
+}
+
+export default async function handler(req: ApiRequest, res: ApiResponse) {
+  // Never cache: a cached response would freeze the counter at one value.
+  res.setHeader("Cache-Control", "no-store");
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    res.status(500).json({ error: "Counter storage is not configured." });
+    return;
+  }
+
+  const redis = new Redis({ url, token });
+
+  try {
+    // Seed on first use so the count continues from the old total instead of
+    // restarting at zero. setnx only writes when the key is absent, so this is
+    // a no-op on every request after the first.
+    await redis.setnx(KEY, SEED);
+
+    const count =
+      req.method === "POST"
+        ? await redis.incr(KEY)
+        : Number(await redis.get<number>(KEY)) || SEED;
+
+    res.status(200).json({ count });
+  } catch (error) {
+    console.error("views counter failed", error);
+    res.status(502).json({ error: "Counter storage unavailable." });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tabler/icons-react": "^3.40.0",
         "@tailwindcss/vite": "^4.1.18",
+        "@upstash/redis": "^1.38.2",
         "framer-motion": "^12.34.0",
         "lucide-react": "^0.563.0",
         "react": "^19.2.4",
@@ -1500,6 +1501,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.2.tgz",
+      "integrity": "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -2452,6 +2462,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tabler/icons-react": "^3.40.0",
     "@tailwindcss/vite": "^4.1.18",
+    "@upstash/redis": "^1.38.2",
     "framer-motion": "^12.34.0",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,44 +32,26 @@ const Footer = () => {
       setVisitorCount(parseInt(cachedCount, 10));
     }
 
-    if (!hasVisited) {
-      // New visitor: increment count and set LocalStorage flag
-      fetch("https://api.counterapi.dev/v1/rohanmukka/portfolio/up")
-        .then((res) => res.json())
-        .then((data) => {
-          if (data && typeof data.count !== "undefined") {
-            setVisitorCount(data.count);
-            localStorage.setItem("portfolioVisited", "true");
-            localStorage.setItem("portfolioCount", data.count.toString());
-          }
-        })
-        .catch((err) =>
-          console.error("Failed to fetch visitor count increment", err),
-        );
-    } else {
-      // Returning visitor: just fetch current count without incrementing
-      fetch("https://api.counterapi.dev/v1/rohanmukka/portfolio")
-        .then((res) => {
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          return res.json();
-        })
-        .then((data) => {
-          if (data && typeof data.count !== "undefined") {
-            setVisitorCount(data.count);
-            localStorage.setItem("portfolioCount", data.count.toString());
-          }
-        })
-        .catch((err) => {
-          console.error(
-            "Failed to read updated visitor count, falling back to cache if available.",
-            err,
-          );
-          // If we had no cached count but the user is marked as visited, let's at least show a fallback so it's not invisible.
-          if (!cachedCount) {
-            setVisitorCount(300); // Approximate current views shown as fallback
-          }
-        });
-    }
+    // A first visit increments the counter; a return visit only reads it.
+    fetch("/api/views", { method: hasVisited ? "GET" : "POST" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (typeof data?.count !== "number") {
+          throw new Error("Malformed counter response");
+        }
+        setVisitorCount(data.count);
+        localStorage.setItem("portfolioVisited", "true");
+        localStorage.setItem("portfolioCount", data.count.toString());
+      })
+      .catch((err) => {
+        // Any cached value is already on screen from above, so leave it there.
+        // With no cache the counter stays hidden, which is preferable to the
+        // previous behaviour of inventing a plausible-looking number.
+        console.error("Failed to load visitor count", err);
+      });
 
     // MonkeyType Stats fetch
     const fetchMonkeyType = async () => {


### PR DESCRIPTION
Fixes the visitor counter in the footer, which has been silently broken.

**Requires two Vercel environment variables before merging** — see Setup below. Without them the counter stays hidden, which is what it already does today, so merging early causes no regression.

## What was wrong

counterapi retired their v1 API. Every request now returns:

```json
{"code":"410","deprecated":true,"message":"This API version (v1) is deprecated and no longer available."}
```

Their v2 API is account-based and the old anonymous workspace does not exist (`404 Workspace not found`), so there was no endpoint to migrate to and the previous total was not recoverable.

The breakage was partly hidden: return visitors kept seeing a stale `localStorage` value or a hardcoded `300`, so the counter looked alive while showing a number that was not real. First-time visitors saw nothing at all, because only the return-visitor path had a fallback.

## What this does

Adds `api/views.ts`, a Vercel serverless function backed by Upstash Redis, so the counter no longer depends on a free third-party service that can disappear:

- `GET /api/views` reads the count
- `POST /api/views` increments and returns the new count

The client sends `POST` on a first visit and `GET` on return visits, same rule as before.

Seeds the key at **333** using `setnx`, the last known total, so the count continues instead of restarting at zero. `setnx` only writes when the key is absent, so it is a no-op after the first request. The first new visitor will see 334.

## Failure handling

Both paths now share one code path. A cached value is kept if present; otherwise the counter stays hidden rather than showing an invented number. The response is validated to contain a numeric `count`, which also guards against the SPA fallback returning `index.html` with a `200` status — a real case, confirmed locally.

## Setup required

1. Create a free Upstash Redis database at upstash.com
2. In the Vercel project settings, add both variables from its REST API section:
   - `UPSTASH_REDIS_REST_URL`
   - `UPSTASH_REDIS_REST_TOKEN`
3. Redeploy

These are read only inside the function, on the server.

## Verification

- `npm run build` and `tsc --noEmit` pass.
- Confirmed `@upstash/redis` and the credential names are absent from the client bundle (`grep` over `dist/`).
- Confirmed the footer renders and the counter hides gracefully when the endpoint is unavailable.
- **Not verified:** the live Redis round trip. This sandbox has no Upstash instance and blocks outbound access to it, so the first real end-to-end check happens on the Vercel preview deploy once the variables are set.

## Scope

Two files: `api/views.ts` (new) and `src/components/Footer.tsx`. Adds `@upstash/redis`. No CSS, no fonts, no other components touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RMFgoe4JvzsUzPSqgQr9Lc)_