### PR TITLE
Temporarily hide Experience/Professional Path link from navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -60,7 +60,8 @@ const Navbar = ({ isScrolled = false }: NavbarProps) => {
 
   const links = [
     { name: "About", href: "#architecture" },
-    { name: "Experience", href: "#experience" },
+    // TODO: re-enable "Experience" (Professional Path section) nav link when ready
+    // { name: "Experience", href: "#experience" },
     { name: "Work", href: "#projects" },
     { name: "Skills", href: "#skills" },
     { name: "Education", href: "#education" },


### PR DESCRIPTION
Comments out the nav entry rather than deleting it so it's easy to restore later; the section itself is untouched.